### PR TITLE
rpm: set proper files attributes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,15 @@
 						<mapping>
 							<directory>/usr/share/${project.name}</directory>
 							<filemode>644</filemode>
-							<username>jboss</username>
-							<groupname>jboss</groupname>
+							<username>root</username>
+							<groupname>root</groupname>
 							<artifact />
+						</mapping>
+						<mapping>
+							<directory>/usr/share/${project.name}</directory>
+							<filemode>755</filemode>
+							<username>root</username>
+							<groupname>root</groupname>
 						</mapping>
 					</mappings>
 				</configuration>


### PR DESCRIPTION
- ensure both dir and file are owned by root
- ensure that dir mode is 755 and file mode is 640

_Side note: it's not exactly an elegant solution, because during the rpm install the files attributes are going to be modified twice, rather being directly set correctly. However, it works, and it is the only solution I managed to come up with the reduced semantics of the maven-rpm-plugin..._

This is the result of the installatin now:

```
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
Setting up Install Process
Examining /input/target/rpm/prbz-overview/RPMS/noarch/prbz-overview-0.2.3.Final-SNAPSHOT20160928140545.noarch.rpm: prbz-overview-0.2.3.Final-SNAPSHOT20160928140545.noarch
Marking /input/target/rpm/prbz-overview/RPMS/noarch/prbz-overview-0.2.3.Final-SNAPSHOT20160928140545.noarch.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package prbz-overview.noarch 0:0.2.3.Final-SNAPSHOT20160928140545 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

==============================================================================================================================================================================================================================================
 Package                                    Arch                                Version                                                           Repository                                                                             Size
==============================================================================================================================================================================================================================================
Installing:
 prbz-overview                              noarch                              0.2.3.Final-SNAPSHOT20160928140545                                /prbz-overview-0.2.3.Final-SNAPSHOT20160928140545.noarch                               13 M

Transaction Summary
==============================================================================================================================================================================================================================================
Install       1 Package(s)

Total size: 13 M
Installed size: 13 M
Downloading Packages:
Running rpm_check_debug
Running Transaction Test
Transaction Test Succeeded
Running Transaction
  Installing : prbz-overview-0.2.3.Final-SNAPSHOT20160928140545.noarch                                                                                                                                                                    1/1 
  Verifying  : prbz-overview-0.2.3.Final-SNAPSHOT20160928140545.noarch                                                                                                                                                                    1/1 

Installed:
  prbz-overview.noarch 0:0.2.3.Final-SNAPSHOT20160928140545                                                                                                                                                                                   

Complete!
drwxr-xr-x. 60 root root 4096 Sep 28 10:06 /usr/share
drwxr-xr-x. 2 root root 64 Sep 28 10:07 /usr/share/prbz-overview
-rw-r--r--. 1 root root 13807170 Sep 28 10:05 /usr/share/prbz-overview/prbz-overview.war

```