### PR TITLE
implement dev profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Since one payload update can sometimes takes several minutes due to server side 
 
 	<coordinator-environment default-timeout="300"/>
 
+### Dev profile
+
+For development purposes you can use a dev profile that will retrieve a small portion of the data and not perform any updates. To enable it add this system property:
+
+    <property name="prbz-dev" value="true"/>
+
 #Deployment
 ------------
 

--- a/src/main/java/org/jboss/set/overview/Util.java
+++ b/src/main/java/org/jboss/set/overview/Util.java
@@ -50,6 +50,8 @@ public class Util {
     public static LinkedHashMap<String, Issue> bzPayloadStore = new LinkedHashMap<>();
     public static LinkedHashMap<String, List<Issue>> jiraPayloadStore = new LinkedHashMap<>();
 
+    private static final boolean devProfile = System.getProperty("prbz-dev") != null;
+
     public static boolean filterComponent(StreamComponent component) {
         String name = component.getName().trim();
         return name.equalsIgnoreCase(Constants.WILDFLY_WILDFLY)
@@ -61,7 +63,8 @@ public class Util {
 
     public static void findAllBugzillaPayloads(Aphrodite aphrodite, boolean first) {
         if (first) {
-            for (int i = 6411; i < 6420; i++) {
+            int max = devProfile ? 6416 : 6420;
+            for (int i = 6411; i < max; i++) {
                 // first time run, search from eap6411-payload to eap6420-payload
                 Issue payloadCandidate = testBzPayloadExistence(aphrodite, i);
                 if (payloadCandidate != null) {
@@ -114,7 +117,8 @@ public class Util {
 
     public static void findAllJiraPayloads(Aphrodite aphrodite, boolean first) {
         if (first) {
-            for (int i = 1; i < 10; i++) {
+            int max = devProfile ? 6 : 10;
+            for (int i = 1; i < max; i++) {
                 // search from 7.0.1.GA to 7.0.9.GA, add to list if result is not empty.
                 String fixVersion = Constants.EAP70XPAYLOAD_ALIAS_PREFIX + i + Constants.EAP70XPAYLOAD_ALIAS_SUFFIX;
                 List<Issue> issues = testJiraPayloadExistence(aphrodite, fixVersion);
@@ -152,10 +156,11 @@ public class Util {
     }
 
     private static List<Issue> testJiraPayloadExistence(Aphrodite aphrodite, String fixVersion) {
+        int maxResults = devProfile ? 10 : 200;
         SearchCriteria sc = new SearchCriteria.Builder()
                 .setRelease(new Release(fixVersion.trim()))
                 .setProduct("JBEAP")
-                .setMaxResults(200)
+                .setMaxResults(maxResults)
                 .build();
         return aphrodite.searchIssues(sc);
     }

--- a/src/main/java/org/jboss/set/overview/ejb/Aider.java
+++ b/src/main/java/org/jboss/set/overview/ejb/Aider.java
@@ -87,6 +87,8 @@ public class Aider {
     private static final Object pullRequestDataLock = new Object();
     private static final Object payloadDataLock = new Object();
 
+    private static final boolean devProfile = System.getProperty("prbz-dev") != null;
+
     @PostConstruct
     public void init() {
         try {
@@ -245,6 +247,7 @@ public class Aider {
 
     @Schedule(minute = "*/30", hour = "*")
     public void updatePullRequestData() {
+        if (devProfile) return;
         logger.info("schedule pull request data update is started ...");
         // TOOD load new streams, although it's not often.
         for (Stream s : allStreams) {
@@ -258,6 +261,7 @@ public class Aider {
 
     @Schedule(minute = "*/30", hour = "*")
     public void updatePayloadData() {
+        if (devProfile) return;
         logger.info("schedule payload data update is started ...");
         findAllBugzillaPayloads(aphrodite, false);
         findAllJiraPayloads(aphrodite, false);

--- a/src/main/java/org/jboss/set/overview/processor/PullRequestOverviewProcessor.java
+++ b/src/main/java/org/jboss/set/overview/processor/PullRequestOverviewProcessor.java
@@ -67,6 +67,8 @@ public class PullRequestOverviewProcessor implements PullRequestProcessor {
 
     private ExecutorService singleExecutorService;
 
+    private static final boolean devProfile = System.getProperty("prbz-dev") != null;
+
     @Override
     public void init(Aphrodite aphrodite) {
         this.aphrodite = aphrodite;
@@ -183,7 +185,11 @@ public class PullRequestOverviewProcessor implements PullRequestProcessor {
         public List<PullRequest> call() throws Exception {
             List<PullRequest> pullRequests = new ArrayList<>();
             pullRequests = aphrodite.getPullRequestsByState(repository, PullRequestState.OPEN);
-            return pullRequests.stream().filter(e -> checkPullRequestBranch(e, stream)).collect(Collectors.toList());
+            java.util.stream.Stream<PullRequest> pullRequestStream = pullRequests.stream();
+            if (devProfile) {
+                pullRequestStream = pullRequestStream.limit(10);
+            }
+            return pullRequestStream.filter(e -> checkPullRequestBranch(e, stream)).collect(Collectors.toList());
         }
     }
 


### PR DESCRIPTION
Adding an option to limit the processing time, with the dev profile enabled the app will only load 10 issues per payload and will not call for updates. This will make it easier to test changes to the front end (as the server won't hang up during redeploy). Let me know if there's a better way to do this, I've never done anything similar.

Closes #29 