### PR TITLE
add expandable rows

### DIFF
--- a/src/main/webapp/css/prbz.css
+++ b/src/main/webapp/css/prbz.css
@@ -1,0 +1,54 @@
+.streams {
+     padding: 5px;
+     width: 280px;
+}
+
+tr.odd:nth-of-type(4n+1),
+tr.odd:nth-of-type(4n+1) > th,
+tr.odd:nth-of-type(4n+1) > td {
+    background-color: #f9f9f9;
+}
+
+tr.even,
+tr.even > th,
+tr.even > td  {
+    background-color: #efefef;
+}
+
+th .switch::before,
+.odd.has-data .switch::before {
+    content: "+";
+    font-size: 18px;
+    font-weight: bold;
+    line-height: 10px;
+    vertical-align: text-bottom;
+}
+
+th.open .switch::before,
+.odd.has-data.open .switch::before {
+    content: "\2212";
+}
+
+.even {
+    display: none;
+}
+
+.open.has-data + .even {
+    display: table-row;
+}
+
+.even .inner-div {
+    display: inline-block;
+    width: 48%;
+}
+
+.issues-table .first-column {
+    width: 120px;
+}
+
+.issues-table .second-column {
+    width: 90px;
+}
+.issues-table .third-column {
+    width: 60px;
+}

--- a/src/main/webapp/js/prbz.js
+++ b/src/main/webapp/js/prbz.js
@@ -1,0 +1,20 @@
+var expandableRows = function() {
+    $('th .switch').parent().on('click',function () {
+        var header = $(this).toggleClass('open');
+        if (header.hasClass('open')) {
+            $('.odd.has-data').addClass('open').find('.switch').attr('title','Collapse');
+            header.find('.switch').attr('title','Collapse All');
+        } else {
+            $('.odd.has-data').removeClass('open').find('.switch').attr('title','Expand');
+            header.find('switch').attr('title','Expand All');
+        }
+    });
+    $('.odd.has-data .switch').parent().on('click', function () {
+        var parent = $(this).parent().toggleClass('open');
+        if (parent.hasClass('open')) {
+            $(this).find('.switch').attr('title','Collapse');
+        } else {
+            $(this).find('.switch').attr('title','Expand');
+        }
+    });
+}

--- a/src/main/webapp/payload.ftl
+++ b/src/main/webapp/payload.ftl
@@ -15,12 +15,7 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
-	<style>
-		.streams {
-             padding: 5px;
-             width: 280px;
-        }
-	</style>
+
   </head>
   <body>
     <script type="text/javascript" src="../js/jquery.min.js"></script>
@@ -28,6 +23,8 @@
     <script type="text/javascript" src="../js/bootstrap.min.js"></script>
     <link href="../css/bootstrap-multiselect.css" rel="stylesheet" type="text/css" />
     <script src="../js/bootstrap-multiselect.js" type="text/javascript"></script>
+    <link href="../css/prbz.css" rel="stylesheet" type="text/css" />
+    <script src="../js/prbz.js"></script>
 
     <ul class="nav nav-pills" style="width: 80%; margin: 6px auto">
         <li style="font-size: 20px"><a href="/prbz-overview/">Home</a></li>
@@ -102,18 +99,33 @@
 		</div>
 		<div class="row">
 		  <div class="col-md-12">
-			  	<table id="eventTable" class="table table-striped">
+			  	<table id="eventTable" class="table">
+                    <colgroup>
+                        <col style="width: 20px">
+                        <col style="width: 140px">
+                        <col style="width: 100px">
+                        <col style="width: 50px">
+                        <col style="width: 150px">
+                        <col>
+                    </colgroup>
 			  		<thead>
 			  			<tr>
-			  				<th>Dendency Issue - Status - Type</th>
-							<th>Pull Requests - Branch - Build Result</th>
-							<th>Depends On - Status - Type</th>
+                            <th><span class="switch" title="Expand All"></span></th>
+                            <th>Dependency Issue</th>
+                            <th>Status</th>
+                            <th>Type</th>
+                            <th>Flags</th>
+                            <th>Violations</th>
 			  			</tr>
 			  		</thead>
 			  		<tbody id="eventTableBody">
 						<#list rows as row>
 							<#assign data = row.data>
-							<tr>
+                            <#assign hasAdditionalData = data.associatedPullRequest?has_content || data.associatedUnrelatedPullRequest?has_content || data.dependsOn?has_content>
+							<tr class="odd<#if hasAdditionalData> has-data</#if>">
+                                <td>
+                                    <span class="switch" title="Expand"></span>
+                                </td>
 								<td>
 									<#if data.payloadDependency.maxSeverity?has_content>
 										<#switch data.payloadDependency.maxSeverity>
@@ -126,121 +138,165 @@
 									<#else>
 										<img src="../images/green-good.png" alt="good green light" title="good">
 									</#if>
-									<a href="${data.payloadDependency.link}" title="${data.payloadDependency.summary}">#${data.payloadDependency.label}</a> - ${data.payloadDependency.status} - ${data.payloadDependency.type}
-									</br>
-									<#if data.payloadDependency.allAcks>
-										<span class="label label-success">Has all 3 acks</span>
-									<#else>
-										<#list data.payloadDependency.flags?keys as key>
-											<#switch data.payloadDependency.flags[key]>
-												<#case "SET"> <span class="label label-primary">${key} ?</span><#break>
-												<#case "ACCEPTED"> <span class="label label-success">${key} +</span><#break>
-												<#case "REJECTED"> <span class="label label-danger">${key} -</span><#break>
-											</#switch>
-										</#list>
-									</#if>
-									<#if data.payloadDependency.maxSeverity?has_content>
-										<#list data.payloadDependency.violations>
-											<ul>
-												<#items as violation>
-													<li>
-														<#switch violation.level>
-																<#case "BLOCKER"><img src="../images/red-blocker.png" alt="red-blocker" title="blocker"><#break>
-																<#case "CRITICAL"><img src="../images/orange-critical.png" alt="orange-critical" title="critical"><#break>
-																<#case "MAJOR"><img src="../images/yellow-major.png" alt="yellow-major" title="major"><#break>
-																<#case "MINOR"><img src="../images/blue-minor.png" alt="blue-minor" title="minor"><#break>
-																<#case "TRIVIAL"><img src="../images/gray-trivial.png" alt="gray-trivial" title="trivial"><#break>
-														</#switch>
-														${violation.level} Violation ${violation.checkName} : ${violation.message}
-													</li>
-												</#items>
-											</ul>
-										</#list>
-									</#if>
-								</td>
-								 <td>
-								 	<#if data.associatedPullRequest?has_content>
-								    	<#list data.associatedPullRequest>
-								    		<ul>
-								    		<#items as patch>
-				  								<li>
-													<a href="${patch.link}">#${patch.label}</a> - ${patch.codebase} -
-													<#switch patch.patchState>
-														<#case "OPEN"> <span class="label label-success">open</span><#break>
-														<#case "CLOSED"> <span class="label label-default">closed</span><#break>
-														<#case "UNDEFINED"> <span class="label label-default">undefined</span><#break>
-													</#switch>
-													<#switch patch.commitStatus>
-														<#case "success"> <span class="label label-success">success</span><#break>
-														<#case "failure"> <span class="label label-warning">failure</span><#break>
-														<#case "error"> <span class="label label-danger">error</span><#break>
-														<#case "pending"> <span class="label label-default">pending</span><#break>
-														<#case "unknown"> <span class="label label-primary">unknown</span><#break>
-													</#switch>
-													<#if patch.noUpstreamRequired?? && (patch.noUpstreamRequired==true)>
-														<span class="label label-success">No Upstream Required</span>
-													</#if>
-				  								</li>
-				  							</#items>
-				  							</ul>
-										</#list>
-									</#if>
-									<#if data.associatedUnrelatedPullRequest?has_content>
-										<#list data.associatedUnrelatedPullRequest>
-											<ul>
-											<#items as patch>
-												<li>
-													<a href="${patch.link}">#${patch.label}</a> - ${patch.codebase} -
-													<#switch patch.patchState>
-														<#case "OPEN"> <span class="label label-success">open</span><#break>
-														<#case "CLOSED"> <span class="label label-default">closed</span><#break>
-														<#case "UNDEFINED"> <span class="label label-default">undefined</span><#break>
-													</#switch>
-													<#switch patch.commitStatus>
-														<#case "success"> <span class="label label-success">success</span><#break>
-														<#case "failure"> <span class="label label-warning">failure</span><#break>
-														<#case "error"> <span class="label label-danger">error</span><#break>
-														<#case "pending"> <span class="label label-default">pending</span><#break>
-														<#case "unknown"> <span class="label label-primary">unknown</span><#break>
-													</#switch>
-													<span class="label label-info">other stream</span>
-													<#if patch.noUpstreamRequired?? && (patch.noUpstreamRequired==true)>
-														<span class="label label-success">No Upstream Required</span>
-													</#if>
-												</li>
-											</#items>
-											</ul>
-										</#list>
-									</#if>
-							    </td>
-							    <td>
-								<#if data.dependsOn?has_content>
-									<#list data.dependsOn>
-										<ul>
-											<#items as issue>
-												<li>
-													<a href="${issue.link}" title="${issue.summary}">#${issue.label}</a> - ${issue.status} - ${issue.type}
-														<#if issue.fixVersions?has_content>
-															- Fix Version:
-															<#list issue.fixVersions as fixVersion> ${fixVersion} </#list>
-														</#if>
-														<#if issue.payload?has_content && (issue.payload != "N/A")>
-															<span class="label label-success">${issue.payload} payload</span>
-														</#if>
-														<#if issue.streamStatus??>
-															<#list issue.streamStatus?keys as key>
-																<span class="label label-primary">${key} stream </span>
-															</#list>
-														</#if>
-														<#if issue.inPayload?? && (issue.inPayload==false)>
-															<span class="label label-warning">Not in Payload</span>
-														</#if>
-												</li>
-											</#items>
-										</ul>
-									</#list>
-									</#if>
-								</td>
+                                    <a href="${data.payloadDependency.link}" title="${data.payloadDependency.summary}">#${data.payloadDependency.label}</a>
+                                </td>
+                                <td>
+                                    ${data.payloadDependency.status}
+                                </td>
+                                <td>
+                                    ${data.payloadDependency.type}
+                                </td>
+                                <td>
+                                    <#if data.payloadDependency.allAcks>
+                                        <span class="label label-success">Has all 3 acks</span>
+                                    <#else>
+                                        <#list data.payloadDependency.flags?keys as key>
+                                            <#switch data.payloadDependency.flags[key]>
+                                                <#case "SET"> <span class="label label-primary">${key} ?</span><#break>
+                                                <#case "ACCEPTED"> <span class="label label-success">${key} +</span><#break>
+                                                <#case "REJECTED"> <span class="label label-danger">${key} -</span><#break>
+                                            </#switch>
+                                        </#list>
+                                    </#if>
+                                </td>
+                                <td>
+                                    <#list data.payloadDependency.violations>
+                                        <ul>
+                                            <#items as violation>
+                                                <li>
+                                                    <#switch violation.level>
+                                                        <#case "BLOCKER"><img src="../images/red-blocker.png" alt="red-blocker" title="blocker"><#break>
+                                                        <#case "CRITICAL"><img src="../images/orange-critical.png" alt="orange-critical" title="critical"><#break>
+                                                        <#case "MAJOR"><img src="../images/yellow-major.png" alt="yellow-major" title="major"><#break>
+                                                        <#case "MINOR"><img src="../images/blue-minor.png" alt="blue-minor" title="minor"><#break>
+                                                        <#case "TRIVIAL"><img src="../images/gray-trivial.png" alt="gray-trivial" title="trivial"><#break>
+                                                    </#switch>
+                                                    ${violation.level} Violation ${violation.checkName} : ${violation.message}
+                                                </li>
+                                            </#items>
+                                        </ul>
+                                    </#list>
+                                </td>
+                            </tr>
+                            <tr class="even">
+                                <td colspan="6">
+                                    <#if data.associatedPullRequest?has_content || data.associatedUnrelatedPullRequest?has_content>
+                                        <div class="inner-div">
+                                            <table class="inner-table table table-striped">
+                                                <thead>
+                                                    <tr>
+                                                        <th>Pull Requests</th>
+                                                        <th>Branch</th>
+                                                        <th>Build Result</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+            								    	<#list data.associatedPullRequest>
+            								    		<#items as patch>
+            				  								<tr>
+                                                                <td>
+                                                                    <a href="${patch.link}">#${patch.label}</a>
+                                                                </td>
+                                                                <td>
+                                                                    ${patch.codebase}
+                                                                </td>
+                                                                <td>
+                													<#switch patch.patchState>
+                														<#case "OPEN"> <span class="label label-success">open</span><#break>
+                														<#case "CLOSED"> <span class="label label-default">closed</span><#break>
+                														<#case "UNDEFINED"> <span class="label label-default">undefined</span><#break>
+                													</#switch>
+                													<#switch patch.commitStatus>
+                														<#case "success"> <span class="label label-success">success</span><#break>
+                														<#case "failure"> <span class="label label-warning">failure</span><#break>
+                														<#case "error"> <span class="label label-danger">error</span><#break>
+                														<#case "pending"> <span class="label label-default">pending</span><#break>
+                														<#case "unknown"> <span class="label label-primary">unknown</span><#break>
+                													</#switch>
+                													<#if patch.noUpstreamRequired?? && (patch.noUpstreamRequired==true)>
+                														<span class="label label-success">No Upstream Required</span>
+                													</#if>
+                				  								</td>
+                                                            </tr>
+            				  							</#items>
+            										</#list>
+            										<#list data.associatedUnrelatedPullRequest>
+            											<#items as patch>
+            												<tr>
+                                                                <td><a href="${patch.link}">#${patch.label}</a></td>
+                                                                <td>${patch.codebase}</td>
+                                                                <td>
+                													<#switch patch.patchState>
+                														<#case "OPEN"> <span class="label label-success">open</span><#break>
+                														<#case "CLOSED"> <span class="label label-default">closed</span><#break>
+                														<#case "UNDEFINED"> <span class="label label-default">undefined</span><#break>
+                													</#switch>
+                													<#switch patch.commitStatus>
+                														<#case "success"> <span class="label label-success">success</span><#break>
+                														<#case "failure"> <span class="label label-warning">failure</span><#break>
+                														<#case "error"> <span class="label label-danger">error</span><#break>
+                														<#case "pending"> <span class="label label-default">pending</span><#break>
+                														<#case "unknown"> <span class="label label-primary">unknown</span><#break>
+                													</#switch>
+                													<span class="label label-info">other stream</span>
+                													<#if patch.noUpstreamRequired?? && (patch.noUpstreamRequired==true)>
+                														<span class="label label-success">No Upstream Required</span>
+                													</#if>
+            												    </td>
+                                                            </tr>
+            											</#items>
+            										</#list>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </#if>
+                                    <#list data.dependsOn>
+                                        <div class="inner-div">
+                                            <table class="inner-table table table-striped issues-table">
+                                                <colgroup>
+                                                    <col class="first-column">
+                                                    <col class="second-column">
+                                                    <col class="third-column">
+                                                    <col>
+                                                </colgroup>
+                                                <thead>
+                                                    <tr>
+                                                        <th>Depends On</th>
+                                                        <th>Status</th>
+                                                        <th>Type</th>
+                                                        <th>Flags</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <#items as issue>
+                                                        <tr>
+                                                            <td><a href="${issue.link}" title="${issue.summary}">#${issue.label}</a></td>
+                                                            <td>${issue.status}</td>
+                                                            <td>${issue.type}</td>
+                                                            <td>
+                                                                <#if issue.fixVersions?has_content>
+                                                                    Fix Version:
+                                                                    <#list issue.fixVersions as fixVersion> ${fixVersion} </#list>
+                                                                </#if>
+                                                                <#if issue.payload?has_content && (issue.payload != "N/A")>
+                                                                    <span class="label label-success">${issue.payload} payload</span>
+                                                                </#if>
+                                                                <#if issue.streamStatus??>
+                                                                    <#list issue.streamStatus?keys as key>
+                                                                        <span class="label label-primary">${key} stream </span>
+                                                                        </#list>
+                                                                </#if>
+                                                                <#if issue.inPayload?? && (issue.inPayload==false)>
+                                                                    <span class="label label-warning">Not in Payload</span>
+                                                                </#if>
+                                                            </td>
+                                                        </tr>
+                                                    </#items>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </#list>
+                                </td>
 							</tr>
 						</#list>
 			  		</tbody>
@@ -261,5 +317,8 @@
 			includeSelectAllOption: true
 		});
 	});
+    $(function() {
+        expandableRows();
+    });
 </script>
 </html>

--- a/src/main/webapp/pullrequest.ftl
+++ b/src/main/webapp/pullrequest.ftl
@@ -15,12 +15,8 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
-	<style>
-		.streams {
-             padding: 5px;
-             width: 280px;
-        }
-	</style>
+    <link href="../css/prbz.css" rel="stylesheet" type="text/css" />
+    <script src="../js/prbz.js"></script>
   </head>
   <body>
       <ul class="nav nav-pills" style="width: 80%; margin: 6px auto">
@@ -44,21 +40,32 @@
 		</div>
 		<div class="row">
 		  <div class="col-md-12"><h4>${Request.pullRequestSize} pull requests on repository</h4></div>
-			  	<table id="eventTable" class="table table-striped">
+			  	<table id="eventTable" class="table">
+                    <colgroup>
+                        <col style="width: 20px">
+                        <col style="width: 330px">
+                        <col style="width: 80px">
+                        <col style="width: 120px">
+                        <col>
+                    </colgroup>
 			  		<thead>
 			  			<tr>
+                            <th><span class="switch" title="Expand All"></span></th>
 			  				<th>Pull Request</th>
 							<th>Branch</th>
 							<th>Streams</th>
 							<th>Issues</th>
-							<th>Other Streams Pull Request</th>
-							<th>Issues Other Streams</th>
 			  			</tr>
 			  		</thead>
 			  		<tbody id="eventTableBody">
 						<#list rows as row>
 							<#assign data = row.data>
-							<tr>
+                            <#assign hasAdditionalData = data.pullRequestsRelated?has_content || data.issuesOtherStreams?has_content>
+                            <#assign issueCount = data.issuesRelated?size>
+							<tr class="odd<#if hasAdditionalData> has-data</#if>">
+                                <td>
+                                    <span class="switch" title="Expand"></span>
+                                </td>
 								<td>
 									<a href="${data.pullRequest.link}">#${data.pullRequest.label}</a>
 									<#switch data.pullRequest.patchState>
@@ -77,96 +84,158 @@
 										<span class="label label-success">No Upstream Required</span>
 									</#if>
 								</td>
-
 								<td>${data.branch}</td>
-
 								<td>
 									<#list data.streams as stream> ${stream} </#list>
 								</td>
-
-								<td>
+                                <td>
 							    	<#list data.issuesRelated>
-							    		<ul>
-							    		<#items as issue>
-											<li>
-												<a href="${issue.link}" title="${issue.summary}">#${issue.label}</a> - ${issue.status} - ${issue.type}
-							    		   		<#assign status = data.status>
-							    		   		<#switch status[issue.label]>
-													  <#case 1> <span class="label label-success">ready to go</span><#break>
-													  <#case 2> <span class="label label-warning">no stream</span><#break>
-													  <#case 3> <span class="label label-danger">flags needed</span><#break>
-												</#switch>
-												<br/>
-												<#list issue.flags?keys as key>
-													<#switch issue.flags[key]>
-														<#case "SET"> <span class="label label-primary">${key} ?</span><#break>
-														<#case "ACCEPTED"> <span class="label label-success">${key} +</span><#break>
-														<#case "REJECTED"> <span class="label label-danger">${key} -</span><#break>
-													</#switch>
-												</#list>
-											</li>
-							    		</#items>
-							    		</ul>
+                                        <div class="inner-div">
+                                        <table class="table issues-table">
+                                            <colgroup>
+                                                <col class="first-column">
+                                                <col class="second-column">
+                                                <col class="third-column">
+                                                <col>
+                                            </colgroup>
+                                            <#items as issue>
+                                                <tr>
+                                                    <td>
+                                                        <a href="${issue.link}" title="${issue.summary}">#${issue.label}</a>
+                                                    </td>
+                                                    <td>
+                                                        ${issue.status}
+                                                    </td>
+                                                    <td>
+                                                        ${issue.type}
+                                                    </td>
+                                                    <#assign status = data.status>
+                                                    <td>
+                                                        <#switch status[issue.label]>
+                                                            <#case 1> <span class="label label-success">ready to go</span><#break>
+                                                            <#case 2> <span class="label label-warning">no stream</span><#break>
+                                                            <#case 3> <span class="label label-danger">flags needed</span><#break>
+                                                        </#switch>
+                                                        <#list issue.flags?keys as key>
+                                                            <#switch issue.flags[key]>
+                                                                <#case "SET"> <span class="label label-primary">${key} ?</span><#break>
+                                                                <#case "ACCEPTED"> <span class="label label-success">${key} +</span><#break>
+                                                                <#case "REJECTED"> <span class="label label-danger">${key} -</span><#break>
+                                                            </#switch>
+                                                        </#list>
+                                                    </td>
+                                                </tr>
+                                            </#items>
+                                        </table>
+                                    </div>
 							    	</#list>
-							    </td>
-
-							    <td>
-							    	<#list data.pullRequestsRelated>
-							    		<ul>
-							    		<#items as patch>
-			  								<li>
-											<a href="${patch.link}">#${patch.label}</a> - ${patch.codebase} -
-											<#switch patch.patchState>
-													<#case "OPEN"> <span class="label label-success">open</span><#break>
-													<#case "CLOSED"> <span class="label label-default">closed</span><#break>
-													<#case "UNDEFINED"> <span class="label label-default">undefined</span><#break>
-												</#switch>
-												<#switch patch.commitStatus>
-													<#case "success"> <span class="label label-success">success</span><#break>
-													<#case "failure"> <span class="label label-warning">failure</span><#break>
-													<#case "error"> <span class="label label-danger">error</span><#break>
-													<#case "pending"> <span class="label label-default">pending</span><#break>
-													<#case "unknown"> <span class="label label-primary">unknown</span><#break>
-												</#switch>
-												<#if patch.noUpstreamRequired?? && (patch.noUpstreamRequired==true)>
-													<span class="label label-success">No Upstream Required</span><#break>
-												</#if>
-			  								</li>
-			  							</#items>
-			  							</ul>
-									</#list>
-							    </td>
-
-							    <td>
-							    	<#list data.issuesOtherStreams>
-							    		<ul>
-							    		<#items as issue>
-							    		   <li>
-												<a href="${issue.link}" title="${issue.summary}">#${issue.label}</a> - ${issue.status} - ${issue.type}
-												<#if issue.streamStatus??>
-													<#list issue.streamStatus?keys as key>
-														<span class="label label-primary">${key}</span>
-													</#list>
-												</#if>
-							    		   		<#assign status = data.status>
-							    		   		<#switch status[issue.label]>
-													  <#case 1> <span class="label label-success">ready to go</span><#break>
-													  <#case 2> <span class="label label-warning">no stream</span><#break>
-													  <#case 3> <span class="label label-danger">flags needed</span><#break>
-												</#switch>
-												<br/>
-												<#list issue.flags?keys as key>
-													<#switch issue.flags[key]>
-														<#case "SET"> <span class="label label-primary">${key} ?</span><#break>
-														<#case "ACCEPTED"> <span class="label label-success">${key} +</span><#break>
-														<#case "REJECTED"> <span class="label label-danger">${key} -</span><#break>
-													</#switch>
-												</#list>
-							    		   </li>
-							    		</#items>
-							    		</ul>
-							    	</#list>
-							    </td>
+                                </td>
+                            </tr>
+                            <tr class="even">
+                                <td colspan="5">
+                                    <#list data.pullRequestsRelated>
+                                        <div class="inner-div">
+                                            <table class="inner-table table table-striped">
+                                                <colgroup>
+                                                    <col style="width:30%">
+                                                    <col style="width:30%">
+                                                    <col style="width:30%">
+                                                </colgroup>
+                                                <thead>
+                                                    <tr>
+                                                        <th>Other Pull Requests</th>
+                                                        <th>Branch</th>
+                                                        <th>Build Result</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+            							    		<#items as patch>
+            			  								<tr>
+                											<td>
+                                                                <a href="${patch.link}">#${patch.label}</a>
+                                                            </td>
+                                                            <td>
+                                                                ${patch.codebase}
+                                                            </td>
+                                                            <td>
+                                                                <#switch patch.patchState>
+                													<#case "OPEN"> <span class="label label-success">open</span><#break>
+                													<#case "CLOSED"> <span class="label label-default">closed</span><#break>
+                													<#case "UNDEFINED"> <span class="label label-default">undefined</span><#break>
+                												</#switch>
+                												<#switch patch.commitStatus>
+                													<#case "success"> <span class="label label-success">success</span><#break>
+                													<#case "failure"> <span class="label label-warning">failure</span><#break>
+                													<#case "error"> <span class="label label-danger">error</span><#break>
+                													<#case "pending"> <span class="label label-default">pending</span><#break>
+                													<#case "unknown"> <span class="label label-primary">unknown</span><#break>
+                												</#switch>
+                												<#if patch.noUpstreamRequired?? && (patch.noUpstreamRequired==true)>
+                													<span class="label label-success">No Upstream Required</span><#break>
+                												</#if>
+                			  								</td>
+                                                        </tr>
+            			  							</#items>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </#list>
+                                    <#list data.issuesOtherStreams>
+                                        <div class="inner-div">
+                                            <table class="inner-table table table-striped issues-table">
+                                                <colgroup>
+                                                    <col class="first-column">
+                                                    <col class="second-column">
+                                                    <col class="third-column">
+                                                    <col>
+                                                </colgroup>
+                                                <thead>
+                                                    <tr>
+                                                        <th>Other Issues</th>
+                                                        <th>Status</th>
+                                                        <th>Type</th>
+                                                        <th>Flags</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <#items as issue>
+                                                        <tr>
+                                                            <td>
+                                                                <a href="${issue.link}" title="${issue.summary}">#${issue.label}</a>
+                                                            </td>
+                                                            <td>
+                                                                ${issue.status}
+                                                            </td>
+                                                            <td>
+                                                                ${issue.type}
+                                                            </td>
+                                                            <td>
+                                                                <#if issue.streamStatus??>
+                                                                    <#list issue.streamStatus?keys as key>
+                                                                        <span class="label label-primary">${key}</span>
+                                                                    </#list>
+                                                                </#if>
+                                                                <#assign status = data.status>
+                                                                <#switch status[issue.label]>
+                                                                    <#case 1> <span class="label label-success">ready to go</span><#break>
+                                                                    <#case 2> <span class="label label-warning">no stream</span><#break>
+                                                                    <#case 3> <span class="label label-danger">flags needed</span><#break>
+                                                                </#switch>
+                                                                <#list issue.flags?keys as key>
+                                                                    <#switch issue.flags[key]>
+                                                                        <#case "SET"> <span class="label label-primary">${key} ?</span><#break>
+                                                                        <#case "ACCEPTED"> <span class="label label-success">${key} +</span><#break>
+                                                                        <#case "REJECTED"> <span class="label label-danger">${key} -</span><#break>
+                                                                    </#switch>
+                                                                </#list>
+                                                            </td>
+                                                        </tr>
+                                                    </#items>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </#list>
+                                </td>
 							</tr>
 						</#list>
 			  		</tbody>
@@ -176,6 +245,10 @@
 	</div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-
+    <script type="text/javascript">
+        $(function() {
+            expandableRows();
+        });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
As mentioned in the mail I tried to make tables more ordered by hiding some of the less important info into expandable rows, e.g. payload view will show only the issue and violations, while PRs and dependent issues are hidden.

The rows can be expanded by clicking the "+" sign which is shown only if there is any additional info to display, the "+" sign in the header will expand all rows.