### PR TITLE
SET-162: column sorting

### DIFF
--- a/src/main/webapp/css/prbz.css
+++ b/src/main/webapp/css/prbz.css
@@ -3,20 +3,22 @@
      width: 280px;
 }
 
-tr.odd:nth-of-type(4n+1),
-tr.odd:nth-of-type(4n+1) > th,
-tr.odd:nth-of-type(4n+1) > td {
+tr.odd,
+tr.odd > th,
+tr.odd > td {
     background-color: #f9f9f9;
 }
 
-tr.even,
-tr.even > th,
-tr.even > td  {
+tr.open + tr > td  {
     background-color: #efefef;
 }
 
-th .switch::before,
-.odd.has-data .switch::before {
+th.switch, td.switch {
+    cursor: pointer;
+}
+
+th.switch span::before,
+.has-data td.switch span::before {
     content: "+";
     font-size: 18px;
     font-weight: bold;
@@ -24,20 +26,12 @@ th .switch::before,
     vertical-align: text-bottom;
 }
 
-th.open .switch::before,
-.odd.has-data.open .switch::before {
+th.open.switch span::before,
+.has-data.open td.switch span::before {
     content: "\2212";
 }
 
-.even {
-    display: none;
-}
-
-.open.has-data + .even {
-    display: table-row;
-}
-
-.even .inner-div {
+.exp.inner-div {
     display: inline-block;
     width: 48%;
 }
@@ -51,4 +45,9 @@ th.open .switch::before,
 }
 .issues-table .third-column {
     width: 60px;
+}
+
+/* override datatables.net styling */
+table.dataTable thead th {
+    padding: 10px;
 }

--- a/src/main/webapp/js/prbz.js
+++ b/src/main/webapp/js/prbz.js
@@ -1,20 +1,101 @@
-var expandableRows = function() {
-    $('th .switch').parent().on('click',function () {
-        var header = $(this).toggleClass('open');
-        if (header.hasClass('open')) {
-            $('.odd.has-data').addClass('open').find('.switch').attr('title','Collapse');
-            header.find('.switch').attr('title','Collapse All');
-        } else {
-            $('.odd.has-data').removeClass('open').find('.switch').attr('title','Expand');
-            header.find('switch').attr('title','Expand All');
+// expandable row formatters
+var formatPullRequests = function(pullRequests) {
+    let table = '';
+
+    pullRequests.forEach(
+        patch => table +=
+        `<tr>
+            <td><a href="${patch.link}">#${patch.label}</a></td>
+            <td>${patch.codebase}</td>
+            <td>${patch.result.join('')}</td>
+        </tr>\n`
+    );
+
+    return table;
+};
+
+var formatIssues = function(issues) {
+    let table = '';
+
+    issues.forEach(
+        issue => table +=
+        `<tr>
+            <td><a href="${issue.link}" title="${issue.summary}">#${issue.label}</a></td>
+            <td>${issue.status}</td>
+            <td>${issue.type}</td>
+            <td>${issue.flags.join('')}</td>
+        </tr>\n`
+    );
+
+    return table;
+};
+
+var formatRow = function(data, payload) {
+    let prTable = '', dTable = '';
+    if (data.pullrequests.length) {
+        prTable =
+        `<div class="exp inner-div">
+            <table class="inner-table table table-striped">
+                <thead>
+                    <tr>
+                        <th>${payload?'':'Other '}Pull Requests</th>
+                        <th>Branch</th>
+                        <th>Build Result</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${formatPullRequests(data.pullrequests)}
+                </tbody>
+            </table>
+        </div>\n`;
+    }
+
+    if (data.issues.length) {
+        dTable =
+        `<div class="exp inner-div">
+            <table class="inner-table table table-striped issues-table">
+                <colgroup>
+                    <col class="first-column">
+                    <col class="second-column">
+                    <col class="third-column">
+                    <col>
+                </colgroup>
+                <thead>
+                    <tr>
+                        <th>${payload?'Depends On':'Other Issues'}</th>
+                        <th>Status</th>
+                        <th>Type</th>
+                        <th>Flags</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${formatIssues(data.issues)}
+                </tbody>
+            </table>
+        </div>\n`;
+    }
+
+    return prTable + dTable;
+};
+
+var expandableRows = function(dataTable, rows, payload) {
+    $('#eventTable tbody').on('click expand collapse', 'td.switch', function (e) {
+        var tr = $(this).closest('tr');
+        var row = dataTable.row(tr);
+
+        if (row.child.isShown() && e.type != "expand") {
+            row.child.hide();
+            tr.removeClass('open');
         }
-    });
-    $('.odd.has-data .switch').parent().on('click', function () {
-        var parent = $(this).parent().toggleClass('open');
-        if (parent.hasClass('open')) {
-            $(this).find('.switch').attr('title','Collapse');
-        } else {
-            $(this).find('.switch').attr('title','Expand');
+        else if (e.type != "collapse") {
+            row.child(formatRow( rows[tr.data('prId')], payload )).show();
+            tr.addClass('open');
         }
+    } );
+
+    $('th.switch').on('click',function () {
+        let header = $(this).toggleClass('open'),
+            eventType = header.hasClass('open') ? 'expand' : 'collapse';
+        $('#eventTable tbody td.switch').trigger(eventType);
     });
 }

--- a/src/main/webapp/macros.ftl
+++ b/src/main/webapp/macros.ftl
@@ -1,0 +1,27 @@
+<#-- macro to output PR data as JSON -->
+<#macro pullRequest list>
+<#list list as patch>
+            {
+                "link": "${patch.link}",
+                "label": "${patch.label}",
+                "codebase": "${patch.codebase}",
+                "result": [
+                    '<#switch patch.patchState>
+                        <#case "OPEN"> <span class="label label-success">open</span><#break>
+                        <#case "CLOSED"> <span class="label label-default">closed</span><#break>
+                        <#case "UNDEFINED"> <span class="label label-default">undefined</span><#break>
+                    </#switch>',
+                    '<#switch patch.commitStatus>
+                        <#case "success"> <span class="label label-success">success</span><#break>
+                        <#case "failure"> <span class="label label-warning">failure</span><#break>
+                        <#case "error"> <span class="label label-danger">error</span><#break>
+                        <#case "pending"> <span class="label label-default">pending</span><#break>
+                        <#case "unknown"> <span class="label label-primary">unknown</span><#break>
+                    </#switch>'
+                    <#if patch.noUpstreamRequired!false>
+                    ,'<span class="label label-success">No Upstream Required</span>'
+                    </#if>
+                ]
+            }<#sep>,
+</#list>
+</#macro>

--- a/src/main/webapp/payload.ftl
+++ b/src/main/webapp/payload.ftl
@@ -1,3 +1,4 @@
+<#import "macros.ftl" as pr>
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -15,17 +16,12 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+    <link href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.min.css" rel="stylesheet" />
+    <link href="../../../../css/bootstrap-multiselect.css" rel="stylesheet" type="text/css" />
+    <link href="../../../../css/prbz.css" rel="stylesheet" type="text/css" />
 
   </head>
   <body>
-    <script type="text/javascript" src="../../../../js/jquery.min.js"></script>
-    <link href="../../../../css/bootstrap.min.css" rel="stylesheet" type="text/css" />
-    <script type="text/javascript" src="../../../../js/bootstrap.min.js"></script>
-    <link href="../../../../css/bootstrap-multiselect.css" rel="stylesheet" type="text/css" />
-    <script src="../../../../js/bootstrap-multiselect.js" type="text/javascript"></script>
-    <link href="../../../../css/prbz.css" rel="stylesheet" type="text/css" />
-    <script src="../../../../js/prbz.js"></script>
-
     <ul class="nav nav-pills" style="width: 80%; margin: 6px auto">
         <li style="font-size: 20px"><a href="/prbz-overview/">Home</a></li>
         <#list payloadSet as payload>
@@ -109,7 +105,8 @@
 			  	<table id="eventTable" class="table">
                     <colgroup>
                         <col style="width: 20px">
-                        <col style="width: 140px">
+                        <col style="width: 20px">
+                        <col style="width: 150px">
                         <col style="width: 100px">
                         <col style="width: 50px">
                         <col style="width: 150px">
@@ -117,7 +114,8 @@
                     </colgroup>
 			  		<thead>
 			  			<tr>
-                            <th><span class="switch" title="Expand All"></span></th>
+                            <th class="switch" title="Expand All"><span></span></th>
+                            <th>S</th>
                             <th>Dependency Issue</th>
                             <th>Status</th>
                             <th>Type</th>
@@ -129,11 +127,11 @@
 						<#list rows as row>
 							<#assign data = row.data>
                             <#assign hasAdditionalData = data.associatedPullRequest?has_content || data.associatedUnrelatedPullRequest?has_content || data.dependsOn?has_content>
-							<tr class="odd<#if hasAdditionalData> has-data</#if>">
-                                <td>
-                                    <span class="switch" title="Expand"></span>
+							<tr<#if hasAdditionalData> class="has-data"</#if> data-pr-id="${data.payloadDependency.label}">
+                                <td<#if hasAdditionalData> class="switch" title="Expand"</#if>>
+                                    <span></span>
                                 </td>
-								<td>
+								<td data-order="${(data.payloadDependency.maxSeverity!"OK")?switch("BLOCKER", 1, "CRITICAL", 2, "MAJOR", 3, "MINOR", 4, "TRIVIAL", 5, 6)}">
 									<#if data.payloadDependency.maxSeverity?has_content>
 										<#switch data.payloadDependency.maxSeverity>
 											<#case "BLOCKER"><img src="../../../../images/red-blocker.png" alt="red-blocker" title="blocker"><#break>
@@ -145,6 +143,8 @@
 									<#else>
 										<img src="../../../../images/green-good.png" alt="good green light" title="good">
 									</#if>
+                                </td>
+                                <td data-order="${data.payloadDependency.label?keep_after('-')?left_pad(5,'0')}">
                                     <a href="${data.payloadDependency.link}" title="${data.payloadDependency.summary}">#${data.payloadDependency.label}</a>
                                 </td>
                                 <td>
@@ -184,126 +184,6 @@
                                         </ul>
                                     </#list>
                                 </td>
-                            </tr>
-                            <tr class="even">
-                                <td colspan="6">
-                                    <#if data.associatedPullRequest?has_content || data.associatedUnrelatedPullRequest?has_content>
-                                        <div class="inner-div">
-                                            <table class="inner-table table table-striped">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Pull Requests</th>
-                                                        <th>Branch</th>
-                                                        <th>Build Result</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-            								    	<#list data.associatedPullRequest>
-            								    		<#items as patch>
-            				  								<tr>
-                                                                <td>
-                                                                    <a href="${patch.link}">#${patch.label}</a>
-                                                                </td>
-                                                                <td>
-                                                                    ${patch.codebase}
-                                                                </td>
-                                                                <td>
-                													<#switch patch.patchState>
-                														<#case "OPEN"> <span class="label label-success">open</span><#break>
-                														<#case "CLOSED"> <span class="label label-default">closed</span><#break>
-                														<#case "UNDEFINED"> <span class="label label-default">undefined</span><#break>
-                													</#switch>
-                													<#switch patch.commitStatus>
-                														<#case "success"> <span class="label label-success">success</span><#break>
-                														<#case "failure"> <span class="label label-warning">failure</span><#break>
-                														<#case "error"> <span class="label label-danger">error</span><#break>
-                														<#case "pending"> <span class="label label-default">pending</span><#break>
-                														<#case "unknown"> <span class="label label-primary">unknown</span><#break>
-                													</#switch>
-                													<#if patch.noUpstreamRequired?? && (patch.noUpstreamRequired==true)>
-                														<span class="label label-success">No Upstream Required</span>
-                													</#if>
-                				  								</td>
-                                                            </tr>
-            				  							</#items>
-            										</#list>
-            										<#list data.associatedUnrelatedPullRequest>
-            											<#items as patch>
-            												<tr>
-                                                                <td><a href="${patch.link}">#${patch.label}</a></td>
-                                                                <td>${patch.codebase}</td>
-                                                                <td>
-                													<#switch patch.patchState>
-                														<#case "OPEN"> <span class="label label-success">open</span><#break>
-                														<#case "CLOSED"> <span class="label label-default">closed</span><#break>
-                														<#case "UNDEFINED"> <span class="label label-default">undefined</span><#break>
-                													</#switch>
-                													<#switch patch.commitStatus>
-                														<#case "success"> <span class="label label-success">success</span><#break>
-                														<#case "failure"> <span class="label label-warning">failure</span><#break>
-                														<#case "error"> <span class="label label-danger">error</span><#break>
-                														<#case "pending"> <span class="label label-default">pending</span><#break>
-                														<#case "unknown"> <span class="label label-primary">unknown</span><#break>
-                													</#switch>
-                													<span class="label label-info">other stream</span>
-                													<#if patch.noUpstreamRequired?? && (patch.noUpstreamRequired==true)>
-                														<span class="label label-success">No Upstream Required</span>
-                													</#if>
-            												    </td>
-                                                            </tr>
-            											</#items>
-            										</#list>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    </#if>
-                                    <#list data.dependsOn>
-                                        <div class="inner-div">
-                                            <table class="inner-table table table-striped issues-table">
-                                                <colgroup>
-                                                    <col class="first-column">
-                                                    <col class="second-column">
-                                                    <col class="third-column">
-                                                    <col>
-                                                </colgroup>
-                                                <thead>
-                                                    <tr>
-                                                        <th>Depends On</th>
-                                                        <th>Status</th>
-                                                        <th>Type</th>
-                                                        <th>Flags</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <#items as issue>
-                                                        <tr>
-                                                            <td><a href="${issue.link}" title="${issue.summary}">#${issue.label}</a></td>
-                                                            <td>${issue.status}</td>
-                                                            <td>${issue.type}</td>
-                                                            <td>
-                                                                <#if issue.fixVersions?has_content>
-                                                                    Fix Version:
-                                                                    <#list issue.fixVersions as fixVersion> ${fixVersion} </#list>
-                                                                </#if>
-                                                                <#if issue.payload?has_content && (issue.payload != "N/A")>
-                                                                    <span class="label label-success">${issue.payload} payload</span>
-                                                                </#if>
-                                                                <#if issue.streamStatus??>
-                                                                    <#list issue.streamStatus?keys as key>
-                                                                        <span class="label label-primary">${key} stream </span>
-                                                                        </#list>
-                                                                </#if>
-                                                                <#if issue.inPayload?? && (issue.inPayload==false)>
-                                                                    <span class="label label-warning">Not in Payload</span>
-                                                                </#if>
-                                                            </td>
-                                                        </tr>
-                                                    </#items>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    </#list>
-                                </td>
 							</tr>
 						</#list>
 			  		</tbody>
@@ -313,19 +193,75 @@
 	</div>
   </body>
 
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
+<script src="../../../../js/bootstrap-multiselect.js" type="text/javascript"></script>
+<script src="../../../../js/prbz.js"></script>
 <script type="text/javascript">
-	$(function() {
-		$('#lstStatus').multiselect({
-			includeSelectAllOption: true
-		});
-	});
-	$(function() {
-		$('#lstFlags').multiselect({
-			includeSelectAllOption: true
-		});
-	});
-    $(function() {
-        expandableRows();
-    });
+    var expRows = {
+        <#list rows as row>
+        <#assign data = row.data>
+        <#if data.associatedPullRequest?has_content || data.associatedUnrelatedPullRequest?has_content || data.dependsOn?has_content>
+        "${data.payloadDependency.label}": {
+            "pullrequests": [
+            <@pr.pullRequest data.associatedPullRequest />
+            <#if data.associatedPullRequest?has_content>,</#if>
+            <@pr.pullRequest data.associatedUnrelatedPullRequest />
+            ],
+            "issues": [
+            <#list data.dependsOn as issue>
+                {
+                    "link": "${issue.link}",
+                    "summary": "${issue.summary?html}",
+                    "label": "${issue.label}",
+                    "status": "${issue.status}",
+                    "type": "${issue.type}",
+                    "flags": [
+                    <#if issue.fixVersions?has_content>
+                        'Fix Version <#list issue.fixVersions as fixVersion> ${fixVersion}<#sep>, </#list>',
+                    </#if>
+                    <#if issue.payload?has_content && (issue.payload != "N/A")>
+                        '<span class="label label-success">${issue.payload} payload</span>',
+                    </#if>
+                    <#if issue.streamStatus??>
+                        <#list issue.streamStatus?keys as key>
+                            '<span class="label label-primary">${key} stream </span>',
+                        </#list>
+                    </#if>
+                    <#if !issue.inPayload!true>
+                        '<span class="label label-warning">Not in Payload</span>',
+                    </#if>
+                        ""
+                    ]
+                }<#sep>,
+            </#list>
+            ]
+        },
+        </#if>
+        </#list>
+        "": "" // required for syntactically correct JSON
+    }
+
+    $(document).ready( function () {
+        var eventTable = $('#eventTable').DataTable({
+            "paging": false,
+            "info": false,
+            "order": [],
+            "columnDefs": [
+                { "orderable": false, "targets": 0 }
+              ]
+        });
+
+        expandableRows(eventTable, expRows, true);
+
+        $('#lstStatus').multiselect({
+            includeSelectAllOption: true
+        });
+
+        $('#lstFlags').multiselect({
+            includeSelectAllOption: true
+        });
+    } );
 </script>
 </html>

--- a/src/main/webapp/pullrequest.ftl
+++ b/src/main/webapp/pullrequest.ftl
@@ -1,3 +1,4 @@
+<#import "macros.ftl" as pr>
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -16,7 +17,7 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
     <link href="../../../../css/prbz.css" rel="stylesheet" type="text/css" />
-    <script src="../../../../js/prbz.js"></script>
+    <link href="//cdn.datatables.net/1.10.20/css/jquery.dataTables.min.css" rel="stylesheet" />
   </head>
   <body>
       <ul class="nav nav-pills" style="width: 80%; margin: 6px auto">
@@ -50,7 +51,7 @@
                     </colgroup>
 			  		<thead>
 			  			<tr>
-                            <th><span class="switch" title="Expand All"></span></th>
+                            <th class="switch" title="Expand All"><span></span></th>
 			  				<th>Pull Request</th>
 							<th>Branch</th>
 							<th>Streams</th>
@@ -62,9 +63,9 @@
 							<#assign data = row.data>
                             <#assign hasAdditionalData = data.pullRequestsRelated?has_content || data.issuesOtherStreams?has_content>
                             <#assign issueCount = data.issuesRelated?size>
-							<tr class="odd<#if hasAdditionalData> has-data</#if>">
-                                <td>
-                                    <span class="switch" title="Expand"></span>
+                            <tr<#if hasAdditionalData> class="has-data"</#if> data-pr-id="${data.pullRequest.label}">
+                                <td<#if hasAdditionalData> class="switch" title="Expand"</#if>>
+                                    <span></span>
                                 </td>
 								<td>
 									<a href="${data.pullRequest.link}">#${data.pullRequest.label}</a>
@@ -131,124 +132,74 @@
 							    	</#list>
                                 </td>
                             </tr>
-                            <tr class="even">
-                                <td colspan="5">
-                                    <#list data.pullRequestsRelated>
-                                        <div class="inner-div">
-                                            <table class="inner-table table table-striped">
-                                                <colgroup>
-                                                    <col style="width:30%">
-                                                    <col style="width:30%">
-                                                    <col style="width:30%">
-                                                </colgroup>
-                                                <thead>
-                                                    <tr>
-                                                        <th>Other Pull Requests</th>
-                                                        <th>Branch</th>
-                                                        <th>Build Result</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-            							    		<#items as patch>
-            			  								<tr>
-                											<td>
-                                                                <a href="${patch.link}">#${patch.label}</a>
-                                                            </td>
-                                                            <td>
-                                                                ${patch.codebase}
-                                                            </td>
-                                                            <td>
-                                                                <#switch patch.patchState>
-                													<#case "OPEN"> <span class="label label-success">open</span><#break>
-                													<#case "CLOSED"> <span class="label label-default">closed</span><#break>
-                													<#case "UNDEFINED"> <span class="label label-default">undefined</span><#break>
-                												</#switch>
-                												<#switch patch.commitStatus>
-                													<#case "success"> <span class="label label-success">success</span><#break>
-                													<#case "failure"> <span class="label label-warning">failure</span><#break>
-                													<#case "error"> <span class="label label-danger">error</span><#break>
-                													<#case "pending"> <span class="label label-default">pending</span><#break>
-                													<#case "unknown"> <span class="label label-primary">unknown</span><#break>
-                												</#switch>
-                												<#if patch.noUpstreamRequired?? && (patch.noUpstreamRequired==true)>
-                													<span class="label label-success">No Upstream Required</span><#break>
-                												</#if>
-                			  								</td>
-                                                        </tr>
-            			  							</#items>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    </#list>
-                                    <#list data.issuesOtherStreams>
-                                        <div class="inner-div">
-                                            <table class="inner-table table table-striped issues-table">
-                                                <colgroup>
-                                                    <col class="first-column">
-                                                    <col class="second-column">
-                                                    <col class="third-column">
-                                                    <col>
-                                                </colgroup>
-                                                <thead>
-                                                    <tr>
-                                                        <th>Other Issues</th>
-                                                        <th>Status</th>
-                                                        <th>Type</th>
-                                                        <th>Flags</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <#items as issue>
-                                                        <tr>
-                                                            <td>
-                                                                <a href="${issue.link}" title="${issue.summary}">#${issue.label}</a>
-                                                            </td>
-                                                            <td>
-                                                                ${issue.status}
-                                                            </td>
-                                                            <td>
-                                                                ${issue.type}
-                                                            </td>
-                                                            <td>
-                                                                <#if issue.streamStatus??>
-                                                                    <#list issue.streamStatus?keys as key>
-                                                                        <span class="label label-primary">${key}</span>
-                                                                    </#list>
-                                                                </#if>
-                                                                <#assign status = data.status>
-                                                                <#switch status[issue.label]>
-                                                                    <#case 1> <span class="label label-success">ready to go</span><#break>
-                                                                    <#case 2> <span class="label label-warning">no stream</span><#break>
-                                                                    <#case 3> <span class="label label-danger">flags needed</span><#break>
-                                                                </#switch>
-                                                                <#list issue.flags?keys as key>
-                                                                    <#switch issue.flags[key]>
-                                                                        <#case "SET"> <span class="label label-primary">${key} ?</span><#break>
-                                                                        <#case "ACCEPTED"> <span class="label label-success">${key} +</span><#break>
-                                                                        <#case "REJECTED"> <span class="label label-danger">${key} -</span><#break>
-                                                                    </#switch>
-                                                                </#list>
-                                                            </td>
-                                                        </tr>
-                                                    </#items>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    </#list>
-                                </td>
-							</tr>
 						</#list>
 			  		</tbody>
 			  	</table>
 		    </div>
 		</div>
 	</div>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-    <script type="text/javascript">
-        $(function() {
-            expandableRows();
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
+<script src="../../../../js/prbz.js"></script>
+<script type="text/javascript">
+    var expRows = {
+        <#list rows as row>
+            <#assign data = row.data>
+            <#if data.pullRequestsRelated?has_content || data.issuesOtherStreams?has_content>
+            "${data.pullRequest.label}": {
+                "pullrequests": [
+                <@pr.pullRequest data.pullRequestsRelated />
+                ],
+                "issues": [
+                <#list data.issuesOtherStreams as issue>
+                    {
+                        "link": "${issue.link}",
+                        "summary": "${issue.summary?html}",
+                        "label": "#${issue.label}",
+                        "status": "${issue.status}",
+                        "type": "${issue.type}",
+                        "flags": [
+                            <#if issue.streamStatus??>
+                                <#list issue.streamStatus?keys as key>
+                                    '<span class="label label-primary">${key}</span>',
+                                </#list>
+                            </#if>
+                            <#assign status = data.status>
+                            '<#switch status[issue.label]>
+                                <#case 1> <span class="label label-success">ready to go</span><#break>
+                                <#case 2> <span class="label label-warning">no stream</span><#break>
+                                <#case 3> <span class="label label-danger">flags needed</span><#break>
+                            </#switch>',
+                            <#list issue.flags?keys as key>
+                                '<#switch issue.flags[key]>
+                                    <#case "SET"> <span class="label label-primary">${key} ?</span><#break>
+                                    <#case "ACCEPTED"> <span class="label label-success">${key} +</span><#break>
+                                    <#case "REJECTED"> <span class="label label-danger">${key} -</span><#break>
+                                </#switch>'<#sep>,
+                            </#list>
+                        ]
+                    }<#sep>,
+                </#list>
+                ]
+            },
+            </#if>
+            </#list>
+        "": "" // required for syntactically correct JSON
+    }
+
+    $(document).ready( function () {
+        var eventTable = $('#eventTable').DataTable({
+            "paging": false,
+            "info": false,
+            "order": [],
+            "columnDefs": [
+                { "orderable": false, "targets": [0, 4] }
+              ]
         });
-    </script>
-  </body>
+
+        expandableRows(eventTable, expRows, false);
+    } );
+</script>
+</body>
 </html>


### PR DESCRIPTION
Issue: [SET-162](https://projects.engineering.redhat.com/browse/SET-162)

there's a request for sortable columns, rather than doing a custom solution I tried using [datatables.net](https://datatables.net). It requires very little setup and seems to work pretty well. The library also supports filtering so we could let it handle the current search implementation.

**This is a preliminary commit**
* only `payload.ftl` has been changed (i.e. pages under EAP Payload List)
* I have split the status image and JIRA id into separate columns so that the status can be sorted by.
* I had to change the expandable rows; they should look and work the same but the rows are created differently, the content is stored in a JSON outside the table
  * I think it would be better if we could entirely separate data from the table but that's for another PR
* some styles have been disabled and the "Expand All" button is not working atm
* the library supports paging but I have disabled that for now, don't know if we want that
![Screenshot from 2020-01-17 12-49-49](https://user-images.githubusercontent.com/1999074/72611067-5de5b900-3929-11ea-9d8e-f6bcd71f9bb3.png)

@soul2zimate can you take a look at this and tell me what you think?