### PR TITLE
[SET-260] Add REST API to query payload and force cache refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,47 @@ Copy generated war file to $JBOSS_HOME/standalone/deployments/ and visit http://
 For instance on thunder: [OverviewPage](https://thunder.sin2.redhat.com/prbz-overview)
 
 In order to avoid potential Github API rate limitation, the scheduled update task updates one payload and one stream Github repositories per hour. Therefore, it may take a bit longer to see all streams / payloads information for the first deployment.
+
+#REST endpoint
+---------------
+/rest/api/ exposes a few management operations:
+
+- `GET /rest/api/payload/{stream}/{release}` - produces JSON representation of issues in payload (using cached data)
+```
+[{
+    "summary": "(7.1.z) Upgrade Infinispan to 8.2.9.Final",
+    "url": "https://issues.redhat.com/browse/JBEAP-14221",
+    "type": "component upgrade",
+    "acks": {
+      "QE": "+",
+      "DEV": "+",
+      "PM": "+"
+    },
+    "status": "VERIFIED",
+    "priority": "BLOCKER"
+  },
+  {
+    "summary": "(7.1.z) RPM - Setting JAVA_HOME not effective in RHEL-6 init scripts",
+    "url": "https://issues.redhat.com/browse/JBEAP-14193",
+    "type": "bug",
+    "acks": {
+      "QE": "+",
+      "DEV": "+",
+      "PM": "?"
+    },
+    "status": "VERIFIED",
+    "priority": "MAJOR"
+  }]
+```
+ - `GET /rest/api/status` - returns current status of PRBZ cache
+```
+{"refreshStatus":"Complete","lastRefresh":"2020-06-27T16:16:54.507"}
+```
+ - `POST /rest/api/refresh` - schedules a full refresh of all PRBZ caches. The operation is executed asynchronously and can be monitored through `/rest/api/status`.
+```
+{"refreshStatus":"Scheduled","lastRefresh":"2020-06-27T16:16:54.507"}
+```
+ - `POST /rest/api/refresh/{stream}/{release}` - schedules a refresh of cached informations for selected release only. The operation is executed asynchronously and can be monitored through `/rest/api/status`.
+```
+{"refreshStatus":"Scheduled","lastRefresh":"2020-06-27T16:16:54.507"}
+```

--- a/README.md
+++ b/README.md
@@ -102,3 +102,7 @@ In order to avoid potential Github API rate limitation, the scheduled update tas
 ```
 {"refreshStatus":"Scheduled","lastRefresh":"2020-06-27T16:16:54.507"}
 ```
+ - `GET /rest/api/payloads` - returns a map of avilable streams/payloads
+```
+{"jboss-eap-7.2.z":["7.2.1.GA","7.2.2.GA"],"jboss-eap-7.3.z":["7.3.1.GA","7.3.2.GA"]}
+```

--- a/src/main/java/org/jboss/set/assist/PatchHomeService.java
+++ b/src/main/java/org/jboss/set/assist/PatchHomeService.java
@@ -90,7 +90,7 @@ public class PatchHomeService implements PatchHome {
         });
     }
 
-    private PatchType getPatchType(URL url) {
+    private static PatchType getPatchType(URL url) {
         String urlStr = url.toString();
         if (urlStr.contains("/pull/"))
             return PatchType.PULLREQUEST;
@@ -100,7 +100,7 @@ public class PatchHomeService implements PatchHome {
             return PatchType.FILE;
     }
 
-    private PatchState getPatchState(URL url, PatchType patchType) {
+    private static PatchState getPatchState(URL url, PatchType patchType) {
         if (patchType.equals(PatchType.PULLREQUEST)) {
             try {
                 PullRequest pullRequest = aphrodite.getPullRequest(url);
@@ -164,5 +164,10 @@ public class PatchHomeService implements PatchHome {
             }
         }
         return commitStatus;
+    }
+
+    public static PatchState getPatchState(URL url) {
+        PatchType patchType = getPatchType(url);
+        return getPatchState(url, patchType);
     }
 }

--- a/src/main/java/org/jboss/set/assist/data/payload/AssociatedPullRequest.java
+++ b/src/main/java/org/jboss/set/assist/data/payload/AssociatedPullRequest.java
@@ -39,10 +39,11 @@ public class AssociatedPullRequest {
     private boolean noUpstreamRequired;
     private URL upstreamIssueFromPRDesc;
     private URL upstreamPullRequestFromPRDesc;
+    private String upstreamPatchState;
 
     public AssociatedPullRequest(String label, URL link, String codebase, String patchState, String commitStatus,
                                  String mergeStatus, boolean noUpstreamRequired, URL upstreamIssueFromPRDesc,
-                                 URL upstreamPullRequestFromPRDesc) {
+                                 URL upstreamPullRequestFromPRDesc, String upstreamPatchState) {
         this.label = label;
         this.link = link;
         this.codebase = codebase;
@@ -52,11 +53,12 @@ public class AssociatedPullRequest {
         this.noUpstreamRequired = noUpstreamRequired;
         this.upstreamIssueFromPRDesc = upstreamIssueFromPRDesc;
         this.upstreamPullRequestFromPRDesc = upstreamPullRequestFromPRDesc;
+        this.upstreamPatchState = upstreamPatchState;
     }
 
     public AssociatedPullRequest(String label, URL link, String codebase, String patchState, String commitStatus,
                                  String mergeStatus, boolean noUpstreamRequired) {
-        this(label, link, codebase, patchState, commitStatus, mergeStatus, noUpstreamRequired, null, null);
+        this(label, link, codebase, patchState, commitStatus, mergeStatus, noUpstreamRequired, null, null, null);
     }
 
     public String getLabel() {
@@ -93,5 +95,9 @@ public class AssociatedPullRequest {
 
     public String getMergeStatus() {
         return mergeStatus;
+    }
+
+    public String getUpstreamPatchState() {
+        return upstreamPatchState;
     }
 }

--- a/src/main/java/org/jboss/set/assist/data/payload/AssociatedPullRequest.java
+++ b/src/main/java/org/jboss/set/assist/data/payload/AssociatedPullRequest.java
@@ -35,23 +35,28 @@ public class AssociatedPullRequest {
     private String codebase;
     private String patchState;
     private String commitStatus;
+    private String mergeStatus;
     private boolean noUpstreamRequired;
     private URL upstreamIssueFromPRDesc;
     private URL upstreamPullRequestFromPRDesc;
 
-    public AssociatedPullRequest(String label, URL link, String codebase, String patchState, String commitStatus, boolean noUpstreamRequired, URL upstreamIssueFromPRDesc, URL upstreamPullRequestFromPRDesc) {
+    public AssociatedPullRequest(String label, URL link, String codebase, String patchState, String commitStatus,
+                                 String mergeStatus, boolean noUpstreamRequired, URL upstreamIssueFromPRDesc,
+                                 URL upstreamPullRequestFromPRDesc) {
         this.label = label;
         this.link = link;
         this.codebase = codebase;
         this.patchState = patchState;
         this.commitStatus = commitStatus;
+        this.mergeStatus = mergeStatus;
         this.noUpstreamRequired = noUpstreamRequired;
         this.upstreamIssueFromPRDesc = upstreamIssueFromPRDesc;
         this.upstreamPullRequestFromPRDesc = upstreamPullRequestFromPRDesc;
     }
 
-    public AssociatedPullRequest(String label, URL link, String codebase, String patchState, String commitStatus, boolean noUpstreamRequired) {
-        this(label, link, codebase, patchState, commitStatus, noUpstreamRequired, null, null);
+    public AssociatedPullRequest(String label, URL link, String codebase, String patchState, String commitStatus,
+                                 String mergeStatus, boolean noUpstreamRequired) {
+        this(label, link, codebase, patchState, commitStatus, mergeStatus, noUpstreamRequired, null, null);
     }
 
     public String getLabel() {
@@ -84,5 +89,9 @@ public class AssociatedPullRequest {
 
     public URL getUpstreamPullRequestFromPRDesc() {
         return upstreamPullRequestFromPRDesc;
+    }
+
+    public String getMergeStatus() {
+        return mergeStatus;
     }
 }

--- a/src/main/java/org/jboss/set/assist/data/payload/DependsOnIssue.java
+++ b/src/main/java/org/jboss/set/assist/data/payload/DependsOnIssue.java
@@ -42,8 +42,8 @@ public class DependsOnIssue extends PayloadIssue {
     private String payload;
     private Map<String, FlagStatus> streamStatus;
 
-    public DependsOnIssue(URL link, String label, String summary, IssueStatus status, IssueType type, Map<String, String> flags, Collection<Violation> violations, boolean inPayload, List<String> fixVersions, String payload, Map<String, FlagStatus> streamStatus) {
-        super(link, label, summary, status, type, flags, false, violations); // for an upstream issue, set allAcks default to false.
+    public DependsOnIssue(URL link, String label, String summary, IssueStatus status, IssueType type, Map<String, String> flags, String priority, Collection<Violation> violations, boolean inPayload, List<String> fixVersions, String payload, Map<String, FlagStatus> streamStatus) {
+        super(link, label, summary, status, type, flags, priority, false, violations); // for an upstream issue, set allAcks default to false.
         this.inPayload = inPayload;
         this.fixVersions = fixVersions;
         this.payload = payload;

--- a/src/main/java/org/jboss/set/assist/data/payload/PayloadIssue.java
+++ b/src/main/java/org/jboss/set/assist/data/payload/PayloadIssue.java
@@ -44,17 +44,21 @@ public class PayloadIssue {
     private IssueStatus status;
     private IssueType type;
     private Map<String, String> flags;
+    private String priority;
     private boolean allAcks;
     private Collection<Violation> violations;
     private Severity maxSeverity;
 
-    public PayloadIssue(URL link, String label, String summary, IssueStatus status, IssueType type, Map<String, String> flags, boolean allAcks, Collection<Violation> violations) {
+    public PayloadIssue(URL link, String label, String summary, IssueStatus status,
+                        IssueType type, Map<String, String> flags, String priority,
+                        boolean allAcks, Collection<Violation> violations) {
         this.link = link;
         this.label = label;
         this.summary = summary;
         this.status = status;
         this.type = type;
         this.flags = flags;
+        this.priority = priority;
         this.allAcks = allAcks;
         this.violations = violations;
         this.maxSeverity = violations.stream().map(violation -> violation.getLevel()).reduce((severity1, severity2) -> maxSeverity(severity1, severity2)).orElse(null);
@@ -82,6 +86,10 @@ public class PayloadIssue {
 
     public Map<String, String> getFlags() {
         return flags;
+    }
+
+    public String getPriority() {
+        return priority;
     }
 
     public boolean isAllAcks() {

--- a/src/main/java/org/jboss/set/assist/evaluator/impl/payload/AssociatedPullRequestEvaluator.java
+++ b/src/main/java/org/jboss/set/assist/evaluator/impl/payload/AssociatedPullRequestEvaluator.java
@@ -103,6 +103,7 @@ public class AssociatedPullRequestEvaluator implements PayloadEvaluator {
             Optional<CommitStatus> commitStatus = PatchHomeService.retrieveCommitStatus(pullRequest);
             URL upstreamIssueFromPRDesc = null;
             URL upstreamPRFromPRDesc = null;
+            String upstreamPatchState = null;
             try {
                 upstreamIssueFromPRDesc = pullRequest.findUpstreamIssueURL();
             } catch (MalformedURLException e) {
@@ -110,6 +111,7 @@ public class AssociatedPullRequestEvaluator implements PayloadEvaluator {
             }
             try {
                 upstreamPRFromPRDesc = pullRequest.findUpstreamPullRequestURL();
+                upstreamPatchState = PatchHomeService.getPatchState(upstreamPRFromPRDesc).name();
             } catch (MalformedURLException e) {
                 logger.log(Level.WARNING, "Can not form upstream pull reuqest url due to : " + e.getMessage());
             }
@@ -117,7 +119,7 @@ public class AssociatedPullRequestEvaluator implements PayloadEvaluator {
                     pullRequest.getCodebase().getName(), pullRequest.getState().toString(),
                     commitStatus.orElse(CommitStatus.UNKNOWN).toString(),
                     pullRequest.getMergableState() == null?null:pullRequest.getMergableState().name(),
-                    isNoUpstreamRequired, upstreamIssueFromPRDesc, upstreamPRFromPRDesc));
+                    isNoUpstreamRequired, upstreamIssueFromPRDesc, upstreamPRFromPRDesc, upstreamPatchState));
         }
         data.put(KEY, relatedDataList);
 

--- a/src/main/java/org/jboss/set/assist/evaluator/impl/payload/AssociatedPullRequestEvaluator.java
+++ b/src/main/java/org/jboss/set/assist/evaluator/impl/payload/AssociatedPullRequestEvaluator.java
@@ -113,14 +113,22 @@ public class AssociatedPullRequestEvaluator implements PayloadEvaluator {
             } catch (MalformedURLException e) {
                 logger.log(Level.WARNING, "Can not form upstream pull reuqest url due to : " + e.getMessage());
             }
-            relatedDataList.add(new AssociatedPullRequest(pullRequest.getId(), pullRequest.getURL(), pullRequest.getCodebase().getName(), pullRequest.getState().toString(), commitStatus.orElse(CommitStatus.UNKNOWN).toString(), isNoUpstreamRequired, upstreamIssueFromPRDesc, upstreamPRFromPRDesc));
+            relatedDataList.add(new AssociatedPullRequest(pullRequest.getId(), pullRequest.getURL(),
+                    pullRequest.getCodebase().getName(), pullRequest.getState().toString(),
+                    commitStatus.orElse(CommitStatus.UNKNOWN).toString(),
+                    pullRequest.getMergableState() == null?null:pullRequest.getMergableState().name(),
+                    isNoUpstreamRequired, upstreamIssueFromPRDesc, upstreamPRFromPRDesc));
         }
         data.put(KEY, relatedDataList);
 
         for (PullRequest pullRequest : unrelatedPullRequests) {
             boolean isNoUpstreamRequired = PatchHomeService.isNoUpstreamRequired(pullRequest);
             Optional<CommitStatus> commitStatus = PatchHomeService.retrieveCommitStatus(pullRequest);
-            unrelatedDataList.add(new AssociatedPullRequest(pullRequest.getId(), pullRequest.getURL(), pullRequest.getCodebase().getName(), pullRequest.getState().toString(),commitStatus.orElse(CommitStatus.UNKNOWN).toString(), isNoUpstreamRequired));
+            unrelatedDataList.add(new AssociatedPullRequest(pullRequest.getId(), pullRequest.getURL(),
+                    pullRequest.getCodebase().getName(), pullRequest.getState().toString(),
+                    commitStatus.orElse(CommitStatus.UNKNOWN).toString(),
+                    pullRequest.getMergableState() == null?null:pullRequest.getMergableState().name(),
+                    isNoUpstreamRequired));
         }
         data.put(KEY_UNRELATED, unrelatedDataList);
     }

--- a/src/main/java/org/jboss/set/assist/evaluator/impl/payload/DependsOnEvaluator.java
+++ b/src/main/java/org/jboss/set/assist/evaluator/impl/payload/DependsOnEvaluator.java
@@ -103,6 +103,7 @@ public class DependsOnEvaluator implements PayloadEvaluator {
                         issue.getSummary().orElse(Constants.NOTAPPLICABLE), issue.getStatus(), issue.getType(),
                         issue.getStage().getStateMap().entrySet().stream()
                                 .collect(Collectors.toMap(e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue()))),
+                        issue.getPriority().name(),
                         Collections.emptyList(), inPayload, getFixVersions(issue), getPayload(issue),
                         issue.getStreamStatus()));
             });
@@ -114,6 +115,7 @@ public class DependsOnEvaluator implements PayloadEvaluator {
                         issue.getSummary().orElse(Constants.NOTAPPLICABLE), issue.getStatus(), issue.getType(),
                         issue.getStage().getStateMap().entrySet().stream()
                                 .collect(Collectors.toMap(e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue()))),
+                        issue.getPriority().name(),
                         Collections.emptyList(), inPayload, getFixVersions(issue), getPayload(issue),
                         issue.getStreamStatus()));
             });

--- a/src/main/java/org/jboss/set/assist/evaluator/impl/payload/PayloadIssueEvaluator.java
+++ b/src/main/java/org/jboss/set/assist/evaluator/impl/payload/PayloadIssueEvaluator.java
@@ -33,6 +33,7 @@ import javax.naming.NameNotFoundException;
 
 import org.jboss.jbossset.bugclerk.Violation;
 import org.jboss.set.aphrodite.domain.Issue;
+import org.jboss.set.aphrodite.issue.trackers.jira.JiraIssue;
 import org.jboss.set.aphrodite.simplecontainer.SimpleContainer;
 import org.jboss.set.assist.Constants;
 import org.jboss.set.assist.Util;
@@ -69,7 +70,12 @@ public class PayloadIssueEvaluator implements PayloadEvaluator {
                 dependencyIssue.getSummary().orElse(Constants.NOTAPPLICABLE), dependencyIssue.getStatus(),
                 dependencyIssue.getType(),
                 dependencyIssue.getStage().getStateMap().entrySet().stream().collect(Collectors.toMap(e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue()))),
+                dependencyIssue.getPriority().name(),
                 Util.isAllAcks(dependencyIssue),
                 violations));
+
+        if (dependencyIssue instanceof JiraIssue) {
+            data.put("incorporatedIssues", ((JiraIssue) dependencyIssue).getLinkedIncorporatesIssues());
+        }
     }
 }

--- a/src/main/java/org/jboss/set/assist/evaluator/impl/pullrequest/PullRequestEvaluator.java
+++ b/src/main/java/org/jboss/set/assist/evaluator/impl/pullrequest/PullRequestEvaluator.java
@@ -63,7 +63,8 @@ public class PullRequestEvaluator implements Evaluator {
             logger.log(Level.FINE, "Unable to find build result for pull request : " + pullRequest.getURL(), e);
         }
         data.put("pullRequest", new AssociatedPullRequest(pullRequest.getId(), pullRequest.getURL(), pullRequest.getCodebase().getName(),
-                pullRequest.getState().toString(), commitStatus.orElse(CommitStatus.UNKNOWN).toString(), isNoUpstreamRequired));
+                pullRequest.getState().toString(), commitStatus.orElse(CommitStatus.UNKNOWN).toString(),
+                pullRequest.getMergableState() == null?null:pullRequest.getMergableState().name(), isNoUpstreamRequired));
 
     }
 

--- a/src/main/java/org/jboss/set/overview/ApiResource.java
+++ b/src/main/java/org/jboss/set/overview/ApiResource.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.overview;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jboss.set.aphrodite.domain.Issue;
+import org.jboss.set.overview.ejb.Aider;
+
+@Path("/api")
+public class ApiResource {
+
+    @Inject
+    private Aider aider;
+    @Inject
+    private PrbzStatus status;
+
+    @GET
+    @Path("/payload/{streamName}/{payloadName}")
+    @Produces("application/json")
+    public Collection<SimpleIssue> generatePayload(@PathParam("streamName") String streamName, @PathParam("payloadName") String payloadName) {
+
+        List<Issue> issues = Util.jiraPayloadStoresByStream.get(streamName).get(payloadName);
+
+        return issues.parallelStream().map(SimpleIssue::from).collect(Collectors.toList());
+    }
+
+    @POST
+    @Path("/refresh")
+    @Produces("application/json")
+    public PrbzStatus scheduleUpdate() {
+        if (status.getRefreshStatus().equals(PrbzStatus.COMPLETE)) {
+            status.setRefreshScheduled();
+            aider.scheduleRefresh();
+        }
+
+        return status;
+    }
+
+    @POST
+    @Path("/refresh/{streamName}/{payloadName}")
+    @Produces("application/json")
+    public PrbzStatus scheduleSingleUpdate(@PathParam("streamName") String streamName, @PathParam("payloadName") String payloadName) {
+        if (status.getRefreshStatus().equals(PrbzStatus.COMPLETE)) {
+            status.setRefreshScheduled();
+            aider.scheduleRefresh(streamName, payloadName);
+        }
+
+        return status;
+    }
+
+    @GET
+    @Path("/status")
+    @Produces("application/json")
+    public PrbzStatus freshnessStatus() {
+        return status;
+    }
+}

--- a/src/main/java/org/jboss/set/overview/ApiResource.java
+++ b/src/main/java/org/jboss/set/overview/ApiResource.java
@@ -36,7 +36,7 @@ public class ApiResource {
     @Inject
     private Aider aider;
     @Inject
-    private PrbzStatus status;
+    private PrbzStatusSingleton status;
 
     @GET
     @Path("/payload/{streamName}/{payloadName}")
@@ -52,30 +52,30 @@ public class ApiResource {
     @Path("/refresh")
     @Produces("application/json")
     public PrbzStatus scheduleUpdate() {
-        if (status.getRefreshStatus().equals(PrbzStatus.COMPLETE)) {
+        if (status.currentState().getRefreshState().equals(PrbzStatusSingleton.COMPLETE)) {
             status.setRefreshScheduled();
             aider.scheduleRefresh();
         }
 
-        return status;
+        return status.currentState();
     }
 
     @POST
     @Path("/refresh/{streamName}/{payloadName}")
     @Produces("application/json")
     public PrbzStatus scheduleSingleUpdate(@PathParam("streamName") String streamName, @PathParam("payloadName") String payloadName) {
-        if (status.getRefreshStatus().equals(PrbzStatus.COMPLETE)) {
+        if (status.currentState().getRefreshState().equals(PrbzStatusSingleton.COMPLETE)) {
             status.setRefreshScheduled();
             aider.scheduleRefresh(streamName, payloadName);
         }
 
-        return status;
+        return status.currentState();
     }
 
     @GET
     @Path("/status")
     @Produces("application/json")
     public PrbzStatus freshnessStatus() {
-        return status;
+        return status.currentState();
     }
 }

--- a/src/main/java/org/jboss/set/overview/ApiResource.java
+++ b/src/main/java/org/jboss/set/overview/ApiResource.java
@@ -24,7 +24,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jboss.set.aphrodite.domain.Issue;
@@ -77,5 +80,18 @@ public class ApiResource {
     @Produces("application/json")
     public PrbzStatus freshnessStatus() {
         return status.currentState();
+    }
+
+    @GET
+    @Path("/payloads")
+    @Produces("application/json")
+    public Map<String, Set<String>> availablePayloads() {
+        Map<String, Set<String>> res = new HashMap<>();
+        for (String stream : Util.jiraPayloadStoresByStream.keySet()) {
+            Set<String> payloads = Util.jiraPayloadStoresByStream.get(stream).keySet();
+            res.put(stream, payloads);
+        }
+
+        return res;
     }
 }

--- a/src/main/java/org/jboss/set/overview/ApiResource.java
+++ b/src/main/java/org/jboss/set/overview/ApiResource.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.jboss.set.aphrodite.domain.Issue;
+import org.jboss.set.assist.data.ProcessorData;
 import org.jboss.set.overview.ejb.Aider;
 
 @Path("/api")
@@ -44,11 +44,12 @@ public class ApiResource {
     @GET
     @Path("/payload/{streamName}/{payloadName}")
     @Produces("application/json")
-    public Collection<SimpleIssue> generatePayload(@PathParam("streamName") String streamName, @PathParam("payloadName") String payloadName) {
+    public Collection<RestIssue> generatePayload(@PathParam("streamName") String streamName, @PathParam("payloadName") String payloadName) {
+        List<ProcessorData> payloadData = Aider.getPayloadData(payloadName);
 
-        List<Issue> issues = Util.jiraPayloadStoresByStream.get(streamName).get(payloadName);
-
-        return issues.parallelStream().map(SimpleIssue::from).collect(Collectors.toList());
+        return payloadData.parallelStream()
+                .map(d-> RestIssue.from(d))
+                .collect(Collectors.toList());
     }
 
     @POST

--- a/src/main/java/org/jboss/set/overview/PrbzStatus.java
+++ b/src/main/java/org/jboss/set/overview/PrbzStatus.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.overview;
+
+import javax.ejb.Singleton;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Singleton
+public class PrbzStatus {
+    public static final String STARTING = "Starting";
+    public static final String REFRESHING = "Refreshing";
+    public static final String COMPLETE = "Complete";
+    public static final String SCHEDULED = "SCHEDULED";
+
+    private DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+    private String refreshStatus = "Starting";
+    private String lastRefresh = ZonedDateTime.now().format(formatter);
+
+    public void refreshStarted() {
+        System.out.println("!!!! REFRESH STARTED");
+        if (!this.refreshStatus.equals(STARTING)) {
+            this.refreshStatus = REFRESHING;
+        }
+    }
+
+    public void refreshCompleted() {
+        this.refreshStatus = COMPLETE;
+        lastRefresh = ZonedDateTime.now().format(formatter);
+    }
+
+    public String getRefreshStatus() {
+        return refreshStatus;
+    }
+
+    public String getLastRefresh() {
+        return lastRefresh;
+    }
+
+    public void setRefreshScheduled() {
+        this.refreshStatus = SCHEDULED;
+    }
+}

--- a/src/main/java/org/jboss/set/overview/PrbzStatus.java
+++ b/src/main/java/org/jboss/set/overview/PrbzStatus.java
@@ -17,42 +17,20 @@
 
 package org.jboss.set.overview;
 
-import javax.ejb.Singleton;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-
-@Singleton
 public class PrbzStatus {
-    public static final String STARTING = "Starting";
-    public static final String REFRESHING = "Refreshing";
-    public static final String COMPLETE = "Complete";
-    public static final String SCHEDULED = "SCHEDULED";
+    private String refreshState = null;
+    private String lastRefresh = null;
 
-    private DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-    private String refreshStatus = "Starting";
-    private String lastRefresh = ZonedDateTime.now().format(formatter);
-
-    public void refreshStarted() {
-        System.out.println("!!!! REFRESH STARTED");
-        if (!this.refreshStatus.equals(STARTING)) {
-            this.refreshStatus = REFRESHING;
-        }
+    public PrbzStatus(String refreshState, String lastRefresh) {
+        this.refreshState = refreshState;
+        this.lastRefresh = lastRefresh;
     }
 
-    public void refreshCompleted() {
-        this.refreshStatus = COMPLETE;
-        lastRefresh = ZonedDateTime.now().format(formatter);
-    }
-
-    public String getRefreshStatus() {
-        return refreshStatus;
+    public String getRefreshState() {
+        return refreshState;
     }
 
     public String getLastRefresh() {
         return lastRefresh;
-    }
-
-    public void setRefreshScheduled() {
-        this.refreshStatus = SCHEDULED;
     }
 }

--- a/src/main/java/org/jboss/set/overview/PrbzStatusSingleton.java
+++ b/src/main/java/org/jboss/set/overview/PrbzStatusSingleton.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.overview;
+
+import javax.ejb.Singleton;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Singleton
+public class PrbzStatusSingleton {
+    public static final String STARTING = "Starting";
+    public static final String REFRESHING = "Refreshing";
+    public static final String COMPLETE = "Complete";
+    public static final String SCHEDULED = "SCHEDULED";
+
+    private DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    private String refreshStatus = STARTING;
+    private String lastRefresh = ZonedDateTime.now().format(formatter);
+
+    public void refreshStarted() {
+        if (!this.refreshStatus.equals(STARTING)) {
+            this.refreshStatus = REFRESHING;
+        }
+    }
+
+    public void refreshCompleted() {
+        this.refreshStatus = COMPLETE;
+        lastRefresh = ZonedDateTime.now().format(formatter);
+    }
+
+    public void setRefreshScheduled() {
+        this.refreshStatus = SCHEDULED;
+    }
+
+    public PrbzStatus currentState() {
+        return new PrbzStatus(refreshStatus, lastRefresh);
+    }
+}

--- a/src/main/java/org/jboss/set/overview/RestIssue.java
+++ b/src/main/java/org/jboss/set/overview/RestIssue.java
@@ -19,6 +19,7 @@ package org.jboss.set.overview;
 
 import javax.xml.bind.annotation.XmlRootElement;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +42,7 @@ public class RestIssue {
 
     public static RestIssue from(ProcessorData d) {
         PayloadIssue issue = (PayloadIssue) d.getData().get("payloadDependency");
-        List<AssociatedPullRequest> associatedPullRequest = (List< AssociatedPullRequest >)d.getData().get("associatedPullRequest");
+        List<AssociatedPullRequest> associatedPullRequest = new ArrayList<>((List< AssociatedPullRequest >)d.getData().get("associatedPullRequest"));
         associatedPullRequest.addAll((List< AssociatedPullRequest >)d.getData().get("associatedUnrelatedPullRequest"));
         List<URL> incorporatedIssues = (List<URL>) d.getData().get("incorporatedIssues");
 

--- a/src/main/java/org/jboss/set/overview/SimpleIssue.java
+++ b/src/main/java/org/jboss/set/overview/SimpleIssue.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.overview;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.set.aphrodite.domain.Flag;
+import org.jboss.set.aphrodite.domain.FlagStatus;
+import org.jboss.set.aphrodite.domain.Issue;
+
+@XmlRootElement(name = "issue")
+public class SimpleIssue {
+
+    private String summary;
+    private URL url;
+    private String type;
+    private Map<String, String> acks = new HashMap<>();
+    private String status;
+    private String priority;
+
+    public static SimpleIssue from(Issue issue) {
+        SimpleIssue simpleIssue = new SimpleIssue();
+        simpleIssue.setSummary(issue.getSummary().get());
+        simpleIssue.setURL(issue.getURL());
+        simpleIssue.setType(issue.getType().get());
+        Map<Flag, FlagStatus> stateMap = issue.getStage().getStateMap();
+        Map<String, String> acks = new HashMap<>();
+        for (Flag flag : stateMap.keySet()) {
+            FlagStatus flagStatus = stateMap.get(flag);
+            acks.put(flag.name(), flagStatus.getSymbol());
+        }
+        simpleIssue.putAcks(acks);
+        simpleIssue.putStatus(issue.getStatus().name());
+        simpleIssue.putPriority(issue.getPriority().name());
+
+        return simpleIssue;
+    }
+
+    private void putPriority(String priority) {
+        this.priority = priority;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    private void putStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    private void putAcks(Map<String, String> acks) {
+        this.acks = acks;
+    }
+
+    public Map<String, String> getAcks() {
+        return acks;
+    }
+
+    private void setType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    private void setURL(URL url) {
+        this.url = url;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+}

--- a/src/main/java/org/jboss/set/overview/SimpleIssue.java
+++ b/src/main/java/org/jboss/set/overview/SimpleIssue.java
@@ -20,11 +20,13 @@ package org.jboss.set.overview;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.jboss.set.aphrodite.domain.Flag;
 import org.jboss.set.aphrodite.domain.FlagStatus;
 import org.jboss.set.aphrodite.domain.Issue;
+import org.jboss.set.aphrodite.issue.trackers.jira.JiraIssue;
 
 @XmlRootElement(name = "issue")
 public class SimpleIssue {
@@ -35,6 +37,8 @@ public class SimpleIssue {
     private Map<String, String> acks = new HashMap<>();
     private String status;
     private String priority;
+    private List<URL> pullRequests;
+    private List<URL> linkedIncorporatesIssues;
 
     public static SimpleIssue from(Issue issue) {
         SimpleIssue simpleIssue = new SimpleIssue();
@@ -47,14 +51,36 @@ public class SimpleIssue {
             FlagStatus flagStatus = stateMap.get(flag);
             acks.put(flag.name(), flagStatus.getSymbol());
         }
-        simpleIssue.putAcks(acks);
-        simpleIssue.putStatus(issue.getStatus().name());
-        simpleIssue.putPriority(issue.getPriority().name());
+        simpleIssue.setAcks(acks);
+        simpleIssue.setStatus(issue.getStatus().name());
+        simpleIssue.setPriority(issue.getPriority().name());
+        if (issue instanceof JiraIssue) {
+            JiraIssue jiraIssue = (JiraIssue) issue;
+            // using JiraIssue to get the list of PRs to avoid having to query JIRA through Issue#getPatches()
+            simpleIssue.setPullRequests(jiraIssue.getPullRequests());
+            simpleIssue.setIncorporatedIssues(jiraIssue.getLinkedIncorporatesIssues());
+        }
 
         return simpleIssue;
     }
 
-    private void putPriority(String priority) {
+    private void setIncorporatedIssues(List<URL> linkedIncorporatesIssues) {
+        this.linkedIncorporatesIssues = linkedIncorporatesIssues;
+    }
+
+    public List<URL> getLinkedIncorporatesIssues() {
+        return linkedIncorporatesIssues;
+    }
+
+    public List<URL> getPullRequests() {
+        return pullRequests;
+    }
+
+    private void setPullRequests(List<URL> patches) {
+        this.pullRequests = patches;
+    }
+
+    private void setPriority(String priority) {
         this.priority = priority;
     }
 
@@ -62,7 +88,7 @@ public class SimpleIssue {
         return priority;
     }
 
-    private void putStatus(String status) {
+    private void setStatus(String status) {
         this.status = status;
     }
 
@@ -70,7 +96,7 @@ public class SimpleIssue {
         return status;
     }
 
-    private void putAcks(Map<String, String> acks) {
+    private void setAcks(Map<String, String> acks) {
         this.acks = acks;
     }
 

--- a/src/main/java/org/jboss/set/overview/ejb/Aider.java
+++ b/src/main/java/org/jboss/set/overview/ejb/Aider.java
@@ -347,7 +347,10 @@ public class Aider {
 
     @Schedule(hour = "1,3,5,7,9,11,13,15,17,19,21,23")
     public void updatePayloadData() {
-        if (devProfile) return;
+        if (devProfile) {
+            status.refreshCompleted();
+            return;
+        }
 
         status.refreshStarted();
 

--- a/src/main/java/org/jboss/set/overview/ejb/Aider.java
+++ b/src/main/java/org/jboss/set/overview/ejb/Aider.java
@@ -66,7 +66,7 @@ import org.jboss.set.assist.data.ProcessorData;
 import org.jboss.set.assist.processor.PayloadProcessor;
 import org.jboss.set.assist.processor.ProcessorException;
 import org.jboss.set.assist.processor.PullRequestProcessor;
-import org.jboss.set.overview.PrbzStatus;
+import org.jboss.set.overview.PrbzStatusSingleton;
 import org.jboss.set.overview.Util;
 
 /**
@@ -95,7 +95,7 @@ public class Aider {
     private static final boolean devProfile = System.getProperty("prbz-dev") != null;
 
     @Inject
-    private PrbzStatus status;
+    private PrbzStatusSingleton status;
 
     @PostConstruct
     public void init() {

--- a/src/main/java/org/jboss/set/overview/ejb/Aider.java
+++ b/src/main/java/org/jboss/set/overview/ejb/Aider.java
@@ -140,9 +140,6 @@ public class Aider {
     }
 
     public void initAllPullRequestData() {
-        if (true) {
-            return;
-        }
         logger.info("pull request data initialization is started.");
         try {
             TimeUnit.MINUTES.sleep(2);// wait for streams loading


### PR DESCRIPTION
JIRA: https://projects.engineering.redhat.com/browse/SET-260

Adding a REST endpoint with following operations:

- `GET /rest/api/payload/{stream}/{release}` - produces JSON representation of issues in payload (using cached data)
```
[{
    "summary": "(7.1.z) Upgrade Infinispan to 8.2.9.Final",
    "url": "https://issues.redhat.com/browse/JBEAP-14221",
    "type": "component upgrade",
    "acks": {
      "QE": "+",
      "DEV": "+",
      "PM": "+"
    },
    "status": "VERIFIED",
    "priority": "BLOCKER"
  },
  {
    "summary": "(7.1.z) RPM - Setting JAVA_HOME not effective in RHEL-6 init scripts",
    "url": "https://issues.redhat.com/browse/JBEAP-14193",
    "type": "bug",
    "acks": {
      "QE": "+",
      "DEV": "+",
      "PM": "?"
    },
    "status": "VERIFIED",
    "priority": "MAJOR"
  }]
```
 - `GET /rest/api/status` - returns current status of PRBZ cache
```
{"refreshStatus":"Complete","lastRefresh":"2020-06-27T16:16:54.507"}
```
 - `POST /rest/api/refresh` - schedules a full refresh of all PRBZ caches. The operation is executed asynchronously and can be monitored through `/rest/api/status`.
```
{"refreshStatus":"Scheduled","lastRefresh":"2020-06-27T16:16:54.507"}
```
 - `POST /rest/api/refresh/{stream}/{release}` - schedules a refresh of cached informations for selected release only. The operation is executed asynchronously and can be monitored through `/rest/api/status`.
```
{"refreshStatus":"Scheduled","lastRefresh":"2020-06-27T16:16:54.507"}
```
