### PR TITLE
SET-300: improve pull request processing, show failures in UI

### DIFF
--- a/src/main/java/org/jboss/set/assist/AssistantClient.java
+++ b/src/main/java/org/jboss/set/assist/AssistantClient.java
@@ -68,7 +68,7 @@ public class AssistantClient {
         simpleContainer.register(IssueHome.class.getSimpleName(), issueHomeService);
         simpleContainer.register(ViolationHome.class.getSimpleName(), violationHomeService);
         simpleContainer.register(PullRequestHome.class.getSimpleName(), GithubPullRequestHomeService);
-        simpleContainer.register(JiraPatchHomeImpl.class.getSimpleName(), new JiraPatchHomeImpl());
+        simpleContainer.register(JiraPatchHomeImpl.class.getSimpleName(), new JiraIssueHomeService());
         simpleContainer.register(CompareHome.class.getSimpleName(), new GithubCompareHomeService(aphrodite));
 
     }

--- a/src/main/java/org/jboss/set/assist/GitUtil.java
+++ b/src/main/java/org/jboss/set/assist/GitUtil.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.set.assist;
+
+import org.jboss.set.aphrodite.Aphrodite;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.spi.NotFoundException;
+import org.jboss.set.assist.data.payload.FailedPullRequest;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GitUtil {
+
+    private static Logger logger = Logger.getLogger(GitUtil.class.getCanonicalName());
+
+    private static String[] prIds = {"/pull/", "/merge_requests/"};
+    private static List<Pattern> patterns = new ArrayList<>();
+
+    static {
+        for (String id : prIds) {
+            patterns.add(Pattern.compile("(.*" + id + "\\d+)/.*"));
+        }
+    }
+
+    public static boolean isValidPRUrl(String urlString) {
+        for (String id : prIds) {
+            if (urlString.contains(id)) return true;
+        }
+        return false;
+    }
+
+    public static PullRequest getPullRequest(Aphrodite aphrodite, URL url) {
+        String urlString = url.toString();
+
+        if (!isValidPRUrl(urlString)) {
+            logger.warning("Invalid pull request url: " + url);
+            return new FailedPullRequest(url, "Invalid URL");
+        }
+
+        // sometimes a URL contains more than necessary, e.g. '/pull/123/files'
+        try {
+            for (Pattern pat : patterns) {
+                Matcher m = pat.matcher(urlString);
+                if (m.find()) {
+                    String newUrl = m.group(1);
+                    url = new URL(newUrl);
+                    break;
+                }
+            }
+        } catch (MalformedURLException mue) {
+        }
+
+        try {
+            return aphrodite.getPullRequest(url);
+        } catch (NotFoundException e) {
+            return new FailedPullRequest(url, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/jboss/set/assist/JiraIssueHomeService.java
+++ b/src/main/java/org/jboss/set/assist/JiraIssueHomeService.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.set.assist;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jboss.set.aphrodite.Aphrodite;
+import org.jboss.set.aphrodite.common.Utils;
+import org.jboss.set.aphrodite.domain.Issue;
+import org.jboss.set.aphrodite.domain.Patch;
+import org.jboss.set.aphrodite.domain.PatchState;
+import org.jboss.set.aphrodite.domain.PatchType;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.issue.trackers.jira.JiraIssue;
+import org.jboss.set.aphrodite.issue.trackers.jira.JiraPatchHomeImpl;
+import org.jboss.set.aphrodite.spi.AphroditeException;
+import org.jboss.set.assist.data.payload.FailedPullRequest;
+
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JiraIssueHomeService extends JiraPatchHomeImpl {
+    private static final Log logger = LogFactory.getLog(JiraIssueHomeService.class);
+
+    @Override
+    public java.util.stream.Stream<Patch> findPatchesByIssue(Issue issue) {
+        List<URL> urls = ((JiraIssue) issue).getPullRequests();
+        return mapURLtoPatchStream(urls);
+    }
+
+    private java.util.stream.Stream<Patch> mapURLtoPatchStream(List<URL> urls) {
+        List<Patch> list = urls.stream().map(e -> {
+            PatchType patchType = getPatchType(e);
+            PatchState patchState = getPatchState(e, patchType);
+            return new Patch(e, patchType, patchState);
+        }).collect(Collectors.toList());
+        return list.stream();
+    }
+
+    private PatchType getPatchType(URL url) {
+        String urlStr = url.toString();
+        if (GitUtil.isValidPRUrl(urlStr))
+            return PatchType.PULLREQUEST;
+        else if (urlStr.contains("/commit/"))
+            return PatchType.COMMIT;
+        else
+            logger.info("patch " + url);
+            return PatchType.FILE;
+    }
+
+    private PatchState getPatchState(URL url, PatchType patchType) {
+        if (patchType.equals(PatchType.PULLREQUEST)) {
+            try {
+                PullRequest pullRequest = GitUtil.getPullRequest(Aphrodite.instance(), url);
+                if (!(pullRequest instanceof FailedPullRequest) && pullRequest.getState() != null) {
+                    return PatchState.valueOf(pullRequest.getState().toString());
+                }
+            } catch (AphroditeException e) {
+                Utils.logException(logger, e);
+            }
+        } else if (patchType.equals(PatchType.COMMIT)) {
+            return PatchState.CLOSED;
+        }
+        return PatchState.UNDEFINED;
+    }
+
+}

--- a/src/main/java/org/jboss/set/assist/PatchHomeService.java
+++ b/src/main/java/org/jboss/set/assist/PatchHomeService.java
@@ -37,6 +37,7 @@ import org.jboss.set.aphrodite.domain.spi.PatchHome;
 import org.jboss.set.aphrodite.issue.trackers.jira.JiraIssue;
 import org.jboss.set.aphrodite.simplecontainer.SimpleContainer;
 import org.jboss.set.aphrodite.spi.NotFoundException;
+import org.jboss.set.assist.data.payload.FailedPullRequest;
 import static org.jboss.set.assist.Util.convertURLtoURI;
 
 import javax.naming.NameNotFoundException;
@@ -131,6 +132,9 @@ public class PatchHomeService implements PatchHome {
     }
 
     public static boolean filterByStream(PullRequest pullRequest, Stream stream) {
+        if (pullRequest instanceof FailedPullRequest) {
+            return false;
+        }
         Codebase codebase = pullRequest.getCodebase();
         Repository repository = pullRequest.getRepository();
         URI uri = convertURLtoURI(repository.getURL());

--- a/src/main/java/org/jboss/set/assist/data/payload/FailedPullRequest.java
+++ b/src/main/java/org/jboss/set/assist/data/payload/FailedPullRequest.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.set.assist.data.payload;
+
+import org.jboss.set.aphrodite.domain.Codebase;
+import org.jboss.set.aphrodite.domain.MergeableState;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.domain.PullRequestState;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+public class FailedPullRequest extends PullRequest {
+
+    public FailedPullRequest(final URL url, final String reason) {
+        super(url.toString().substring(url.toString().lastIndexOf("/") + 1), url, null, new Codebase(""), PullRequestState.UNDEFINED, reason, "",
+                false, false, MergeableState.UNKNOWN, null, Collections.EMPTY_LIST, null);
+    }
+
+    @Override
+    public URL findUpstreamPullRequestURL() {
+        return null;
+    }
+
+    @Override
+    public URL findUpstreamIssueURL() {
+        return null;
+    }
+
+    @Override
+    public URL findIssueURL() {
+        return null;
+    }
+
+    @Override
+    public List<URL> findRelatedIssuesURL() {
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public List<URL> findDependencyPullRequestsURL() {
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public boolean hasUpgrade() {
+        return false;
+    }
+}

--- a/src/main/java/org/jboss/set/assist/evaluator/impl/payload/AssociatedPullRequestEvaluator.java
+++ b/src/main/java/org/jboss/set/assist/evaluator/impl/payload/AssociatedPullRequestEvaluator.java
@@ -29,7 +29,7 @@ import org.jboss.set.aphrodite.domain.Patch;
 import org.jboss.set.aphrodite.domain.PatchType;
 import org.jboss.set.aphrodite.domain.PullRequest;
 import org.jboss.set.aphrodite.domain.Stream;
-import org.jboss.set.aphrodite.spi.NotFoundException;
+import org.jboss.set.assist.GitUtil;
 import org.jboss.set.assist.PatchHomeService;
 import org.jboss.set.assist.data.payload.AssociatedPullRequest;
 import org.jboss.set.assist.evaluator.PayloadEvaluator;
@@ -43,7 +43,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -76,15 +75,8 @@ public class AssociatedPullRequestEvaluator implements PayloadEvaluator {
 
         Aphrodite aphrodite = context.getAphrodite();
 
-        allPullRequests = allPatches.filter(e -> e.getPatchType().equals(PatchType.PULLREQUEST)).map(e -> {
-            URL url = e.getUrl();
-            try {
-                return aphrodite.getPullRequest(url);
-            } catch (NotFoundException ex) {
-                logger.log(Level.WARNING, "Can not get pull request from url : " + url + " due to : " + ex);
-            }
-            return null;
-        }).filter(Objects::nonNull).collect(Collectors.toList());
+        allPullRequests = allPatches.filter(e -> e.getPatchType().equals(PatchType.PULLREQUEST))
+                .map(e -> GitUtil.getPullRequest(aphrodite, e.getUrl())).collect(Collectors.toList());
 
         Stream stream = context.getStream();
 

--- a/src/main/webapp/css/prbz.css
+++ b/src/main/webapp/css/prbz.css
@@ -47,6 +47,10 @@ th.open.switch span::before,
     width: 60px;
 }
 
+.failed-to-load td {
+    background: #f63;
+}
+
 /* override datatables.net styling */
 table.dataTable thead th {
     padding: 10px;

--- a/src/main/webapp/js/prbz.js
+++ b/src/main/webapp/js/prbz.js
@@ -4,7 +4,7 @@ var formatPullRequests = function(pullRequests) {
 
     pullRequests.forEach(
         patch => table +=
-        `<tr>
+        `<tr class="${patch.codebase?'':'failed-to-load'}">
             <td><a href="${patch.link}">#${patch.label}</a></td>
             <td>${patch.codebase}</td>
             <td>${patch.result.join('')}</td>


### PR DESCRIPTION
(This might need some work but I wanted to put it up before I go on PTO)

Issue: [SET-300](https://projects.engineering.redhat.com/browse/SET-300)

The idea is to return a FailedPullRequest when Aphrodite can't find anything (for whatever reason) but also made it so we won't reject certain URLs. This should not interfere with the evaluators. In the webapp the failed PRs will show up with red background.