### PR TITLE
Add a released-disabled option to disable retrieving released payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ For development purposes you can use a dev profile that will retrieve a small po
 
     <property name="prbz-dev" value="true"/>
 
+### Released disabled option
+
+It's possible to configure a system property `released-disabled` to disable retrieving released payloads. To configure it add this system property:
+
+    <property name="released-disabled" value="true"/>
+
 #Deployment
 ------------
 

--- a/src/main/java/org/jboss/set/assist/Constants.java
+++ b/src/main/java/org/jboss/set/assist/Constants.java
@@ -76,5 +76,6 @@ public class Constants {
     public static final String NOTAPPLICABLE = "N/A";
 
     public static final String DEV_PROFILE = "prbz-dev";
+    public static final String RELEASED_DISABLED = "released-disabled";
     public static final String DEV_STREAM = "7.3";
 }

--- a/src/main/java/org/jboss/set/overview/ejb/Aider.java
+++ b/src/main/java/org/jboss/set/overview/ejb/Aider.java
@@ -98,7 +98,11 @@ public class Aider {
     private static final Object pullRequestDataLock = new Object();
     private static final Object payloadDataLock = new Object();
 
-    private static final boolean devProfile = System.getProperty(DEV_PROFILE) != null;
+    private static final boolean devProfile;
+    static {
+        String devProfileValue = Util.getValueFromPropertyAndEnv(DEV_PROFILE);
+        devProfile =  devProfileValue != null ? Boolean.valueOf(devProfileValue): false;
+    }
 
     @Inject
     private PrbzStatusSingleton status;


### PR DESCRIPTION
Add `released-disabled` allow to disable retrieving released payloads.

This also fixes devprofile logic which consider all non null value is `true`. In that case, if `prbz_dev` set to `false`, it's consider devprofile is `on`.

Last, this double checks environment variable if system property is null, this allows to use properties defined in ConfigMap.