### PR TITLE
SET-556: add an API endpoint to retrieve new issues in payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,10 @@ In order to avoid potential Github API rate limitation, the scheduled update tas
     "newVersion":"2.3.9.SP12-redhat-00001"
 }]
 ```
+- `GET /rest/api/new-issues/{payload}/{since}` - returns a list of issue urls that have been added to a payload since a given date
+```
+[
+    "https://issues.redhat.com/browse/JBEAP-14221",
+    "https://issues.redhat.com/browse/JBEAP-14193"
+]
+```

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<version.jboss.spec.javaee.7.0>1.0.3.Final</version.jboss.spec.javaee.7.0>
 		<version.org.freemaker.freemarker>2.3.23</version.org.freemaker.freemarker>
 		<version.org.jboss.jbossset.bugclerk>1.0.5.Final</version.org.jboss.jbossset.bugclerk>
-		<version.org.jboss.set.aphrodite>0.7.16.Final</version.org.jboss.set.aphrodite>
+		<version.org.jboss.set.aphrodite>0.7.18.Final</version.org.jboss.set.aphrodite>
 		<version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
 		<version.org.wildfly.wildfly.build.config>8.0.0.Final</version.org.wildfly.wildfly.build.config>
 		<version.resources.plugin>2.6</version.resources.plugin>

--- a/src/main/java/org/jboss/set/overview/ApiResource.java
+++ b/src/main/java/org/jboss/set/overview/ApiResource.java
@@ -115,4 +115,11 @@ public class ApiResource {
     public List<String> getTags(@PathParam("comp") String comp) {
         return aider.getTagsAndBranches(comp);
     }
+
+    @GET
+    @Path("/new-issues/{payload}/{since}")
+    @Produces("application/json")
+    public List<String> getNewIssues(@PathParam("payload") String payload, @PathParam("since") String since) {
+        return aider.getNewIssuesSince(payload, since);
+    }
 }

--- a/src/main/java/org/jboss/set/overview/Util.java
+++ b/src/main/java/org/jboss/set/overview/Util.java
@@ -40,7 +40,9 @@ import static org.jboss.set.assist.Constants.RELEASED_DISABLED;
 import javax.naming.NameNotFoundException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -218,6 +220,23 @@ public class Util {
             }
         }
         return result;
+    }
+
+    public static List<String> getNewIssuesInPayload(String fixVersion, String since) {
+        try {
+            String shortStreamName = fixVersion.substring(0,3);
+            for (JiraRelease release : jiraVersions.get(shortStreamName)) {
+                if (release.getVersion().getName().equals(fixVersion)) {
+                    LocalDate sinceDate = LocalDate.parse(since);
+                    return release.getNewIssues(sinceDate, null).stream()
+                            .map(issue -> issue.getURL().toString()).collect(Collectors.toList());
+                }
+            }
+        } catch (NameNotFoundException e) {
+            logger.log(Level.WARNING, e.getMessage(), e);
+        }
+
+        return Collections.EMPTY_LIST;
     }
 
     public static String getValueFromPropertyAndEnv(String key) {

--- a/src/main/java/org/jboss/set/overview/ejb/Aider.java
+++ b/src/main/java/org/jboss/set/overview/ejb/Aider.java
@@ -434,4 +434,8 @@ public class Aider {
         }
         return Collections.EMPTY_LIST;
     }
+
+    public static List<String> getNewIssuesSince(String version, String since) {
+        return Util.getNewIssuesInPayload(version, since);
+    }
 }


### PR DESCRIPTION
Issue: [SET-556](https://issues.redhat.com/browse/SET-556)

Blocked by: jboss-set/aphrodite#264 (and a new Aphrodite release)

Adding an endpoint to get new issues, unfortunately there doesn't seem to be a better way of doing this (i.e. through issue changelog, since we don't have access to those)